### PR TITLE
Readme history updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,20 @@ History
 
 The original [Subsonic](http://www.subsonic.org/) is developed by [Sindre Mehus](mailto:sindre@activeobjects.no). Subsonic was open source through version 6.0-beta1, and closed-source from then onwards.
 
-Airsonic is maintained by [Eugene E. Kashpureff Jr](mailto:eugene@kashpureff.org). It originated as an unofficial("Kang") of Subsonic which did not contain the Licensing code checks present in the official builds. With the announcement of Subsonic's closed-source future, a decision was made to make a full fork and rebrand to Airsonic.
+Libresonic was created and maintained by [Eugene E. Kashpureff Jr](mailto:eugene@kashpureff.org). It originated as an unofficial("Kang") of Subsonic which did not contain the Licensing code checks present in the official builds. With the announcement of Subsonic's closed-source future, a decision was made to make a full fork and rebrand to Libresonic.
 
-Airsonic will strive to maintain compatibility and stability for Subsonic users, including a clean upgrade path. New features and refactoring are welcomed as a Pull Request on GitHub.
+Around July 2017, it was discovered that Eugene had different intentions/goals
+for the project than some contributors had.  Although the developers were
+hesitant to create a fork as it would fracture/confuse the community even
+further, it was deemed necessary in order to preserve a community-focused fork.
+To reiterate this more clearly:
 
+Airsonic's goal is to provide a full-featured, stable, self-hosted media server
+based on the Subsonic codebase that is free, open source, and community driven.
+
+Pull Requests are always welcome. Keep in mind that we strive to balance
+stability with new features. As such, all Pull Requests are reviewed before
+being merged to ensure we continue to meet our goals.
 
 License
 -------


### PR DESCRIPTION
Requires #489 

Updates history section with reason for forking into airsonic.

Suggestions welcome - I want to keep it as neutral/amiable as possible while still keeping all the important bits. Perhaps we should remove the IRC converstation history? Not sure if its necessary but I think it details best how Libresonic's goals differ from Airsonic's.