### PR TITLE
Added profile to embed additional jdbc drivers

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -553,5 +553,31 @@
                 <boot.artifact.excludes>spring-boot-starter-tomcat</boot.artifact.excludes>
             </properties>
         </profile>
+        <profile>
+            <id>jdbc-extra</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                    <version>42.1.4</version>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                    <version>5.1.43</version>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.mariadb.jdbc</groupId>
+                    <artifactId>mariadb-java-client</artifactId>
+                    <version>2.1.0</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <finalName>airsonic-jdbc-extra</finalName>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This adds a maven profile to add additional jdbc drivers. The drivers added were from the list tested at https://airsonic.github.io/docs/database.

With this, there are two options on packaging this:

1. Provide two war files. One built without this profile and one with.
2. Provide a single war file with the jdbc drivers as its only an additional 2MB in size.

I think it might be prudent to do 1 for now, but warn users that a some point, the additional jdbc drivers will be included in the main airsonic.war. Then in the future, we will provide only a single war to keep things simple.

Signed-off-by: Andrew DeMaria <lostonamountain@gmail.com>
