### PR TITLE
Docker - expose context path configuration

### DIFF
--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.6
 LABEL description="Airsonic is a free, web-based media streamer, providing ubiquitious access to your music." \
       url="https://github.com/airsonic/airsonic"
 
-ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/airsonic
+ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/airsonic CONTEXT_PATH=/
 
 WORKDIR $AIRSONIC_DIR
 

--- a/install/docker/run.sh
+++ b/install/docker/run.sh
@@ -15,7 +15,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
     exec java -Xmx256m \
      -Dserver.host=0.0.0.0 \
      -Dserver.port=$AIRSONIC_PORT \
-     -Dserver.contextPath=/ \
+     -Dserver.contextPath=$CONTEXT_PATH \
      -Dairsonic.home=$AIRSONIC_DIR/data \
      -Dairsonic.defaultMusicFolder=$AIRSONIC_DIR/musics \
      -Dairsonic.defaultPodcastFolder=$AIRSONIC_DIR/podcasts \


### PR DESCRIPTION
Change the context path with an environment variable. 

I want to run Airsonic from a specific path of my domain: ``https://sol.nullsum.net/airsonic/``
The ability to change the context path is required to do this. 

I've confirmed that this change allows me to set the path. It can be seen working at [https://sol.nullsum.net/airsonic/](https://sol.nullsum.net/airsonic/).