### PR TITLE
Autowire dao service and component scan

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/CoverArtService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/CoverArtService.java
@@ -33,6 +33,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -47,12 +49,16 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Service("ajaxCoverArtService")
 public class CoverArtService {
 
     private static final Logger LOG = LoggerFactory.getLogger(CoverArtService.class);
 
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private LastFmService lastFmService;
 
     public List<LastFmCoverArt> searchCoverArt(String artist, String album) {

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/LyricsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/LyricsService.java
@@ -33,6 +33,7 @@ import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -47,6 +48,7 @@ import java.net.SocketException;
  *
  * @author Sindre Mehus
  */
+@Service("ajaxLyricsService")
 public class LyricsService {
 
     private static final Logger LOG = LoggerFactory.getLogger(LyricsService.class);

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/MultiService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/MultiService.java
@@ -30,6 +30,8 @@ import org.airsonic.player.service.SettingsService;
 import org.directwebremoting.WebContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -45,13 +47,18 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Service("ajaxMultiService")
 public class MultiService {
 
     private static final Logger LOG = LoggerFactory.getLogger(MultiService.class);
 
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private LastFmService lastFmService;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private SettingsService settingsService;
 
     public ArtistInfo getArtistInfo(int mediaFileId, int maxSimilarArtists, int maxTopSongs) {

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/NowPlayingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/NowPlayingService.java
@@ -27,6 +27,8 @@ import org.directwebremoting.WebContext;
 import org.directwebremoting.WebContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -40,13 +42,18 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Service("ajaxNowPlayingService")
 public class NowPlayingService {
 
     private static final Logger LOG = LoggerFactory.getLogger(NowPlayingService.class);
 
+    @Autowired
     private PlayerService playerService;
+    @Autowired
     private StatusService statusService;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private MediaScannerService mediaScannerService;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueService.java
@@ -28,6 +28,8 @@ import org.airsonic.player.service.*;
 import org.airsonic.player.service.PlaylistService;
 import org.airsonic.player.util.StringUtil;
 import org.directwebremoting.WebContextFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.support.RequestContextUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -41,22 +43,37 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Service("ajaxPlayQueueService")
 @SuppressWarnings("UnusedDeclaration")
 public class PlayQueueService {
 
+    @Autowired
     private PlayerService playerService;
+    @Autowired
     private JukeboxService jukeboxService;
+    @Autowired
     private TranscodingService transcodingService;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private LastFmService lastFmService;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private SearchService searchService;
+    @Autowired
     private RatingService ratingService;
+    @Autowired
     private PodcastService podcastService;
+    @Autowired
     private PlaylistService playlistService;
+    @Autowired
     private MediaFileDao mediaFileDao;
+    @Autowired
     private PlayQueueDao playQueueDao;
+    @Autowired
     private JWTSecurityService jwtSecurityService;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/PlaylistService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/PlaylistService.java
@@ -30,6 +30,8 @@ import org.airsonic.player.service.PlayerService;
 import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.SettingsService;
 import org.directwebremoting.WebContextFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -43,14 +45,22 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Service("ajaxPlaylistService")
 public class PlaylistService {
 
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private org.airsonic.player.service.PlaylistService playlistService;
+    @Autowired
     private MediaFileDao mediaFileDao;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private PlayerService playerService;
+    @Autowired
     private LocaleResolver localeResolver;
 
     public List<Playlist> getReadablePlaylists() {

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/StarService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/StarService.java
@@ -26,6 +26,8 @@ import org.directwebremoting.WebContext;
 import org.directwebremoting.WebContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 /**
  * Provides AJAX-enabled services for starring.
@@ -34,11 +36,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Sindre Mehus
  */
+@Service("ajaxStarService")
 public class StarService {
 
     private static final Logger LOG = LoggerFactory.getLogger(StarService.class);
 
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private MediaFileDao mediaFileDao;
 
     public void star(int id) {

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/TagService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/TagService.java
@@ -29,6 +29,8 @@ import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 /**
  * Provides AJAX-enabled services for editing tags in music files.
@@ -36,11 +38,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Sindre Mehus
  */
+@Service("ajaxTagService")
 public class TagService {
 
     private static final Logger LOG = LoggerFactory.getLogger(TagService.class);
 
+    @Autowired
     private MetaDataParserFactory metaDataParserFactory;
+    @Autowired
     private MediaFileService mediaFileService;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/TransferService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/TransferService.java
@@ -22,15 +22,16 @@ package org.airsonic.player.ajax;
 import org.airsonic.player.controller.UploadController;
 import org.airsonic.player.domain.TransferStatus;
 import org.directwebremoting.WebContextFactory;
+import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpSession;
-
 /**
  * Provides AJAX-enabled services for retrieving the status of ongoing transfers.
  * This class is used by the DWR framework (http://getahead.ltd.uk/dwr/).
  *
  * @author Sindre Mehus
  */
+@Service("ajaxTransferService")
 public class TransferService {
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AbstractDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AbstractDao.java
@@ -21,6 +21,7 @@ package org.airsonic.player.dao;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -38,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 public class AbstractDao {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDao.class);
     
+    @Autowired
     private DaoHelper daoHelper;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
@@ -25,6 +25,7 @@ import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.util.FileUtil;
 import org.apache.commons.lang.ObjectUtils;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -36,6 +37,7 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class AlbumDao extends AbstractDao {
     private static final String INSERT_COLUMNS = "path, name, artist, song_count, duration_seconds, cover_art_path, " +
                                           "year, genre, play_count, last_played, comment, created, last_scanned, present, folder_id";

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
@@ -24,6 +24,7 @@ import org.airsonic.player.domain.MusicFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -35,6 +36,7 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class ArtistDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(ArtistDao.class);

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AvatarDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AvatarDao.java
@@ -21,6 +21,7 @@ package org.airsonic.player.dao;
 
 import org.airsonic.player.domain.Avatar;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -31,6 +32,7 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class AvatarDao extends AbstractDao {
 
     private static final String INSERT_COLUMNS = "name, created_date, mime_type, width, height, data";

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/BookmarkDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/BookmarkDao.java
@@ -21,6 +21,7 @@ package org.airsonic.player.dao;
 
 import org.airsonic.player.domain.Bookmark;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -32,6 +33,7 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class BookmarkDao extends AbstractDao {
 
     private static final String INSERT_COLUMNS = "media_file_id, position_millis, username, comment, created, changed";

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/InternetRadioDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/InternetRadioDao.java
@@ -23,6 +23,7 @@ import org.airsonic.player.domain.InternetRadio;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -33,6 +34,7 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class InternetRadioDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(InternetRadioDao.class);

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -39,6 +40,7 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class MediaFileDao extends AbstractDao {
     private static final Logger logger = LoggerFactory.getLogger(MediaFileDao.class);
     private static final String INSERT_COLUMNS = "path, folder, type, format, title, album, artist, album_artist, disc_number, " +

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/MusicFolderDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/MusicFolderDao.java
@@ -22,7 +22,9 @@ package org.airsonic.player.dao;
 import org.airsonic.player.domain.MusicFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 
 import java.io.File;
 import java.sql.ResultSet;
@@ -34,13 +36,15 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class MusicFolderDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(MusicFolderDao.class);
     private static final String INSERT_COLUMNS = "path, name, enabled, changed";
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
     private final MusicFolderRowMapper rowMapper = new MusicFolderRowMapper();
-
+    
+    @Autowired
     private UserDao userDao;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PlayQueueDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PlayQueueDao.java
@@ -20,6 +20,7 @@ package org.airsonic.player.dao;
 
 import org.airsonic.player.domain.SavedPlayQueue;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -31,6 +32,7 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class PlayQueueDao extends AbstractDao {
 
     private static final String INSERT_COLUMNS = "username, current, position_millis, changed, changed_by";

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PlayerDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PlayerDao.java
@@ -23,6 +23,7 @@ import org.airsonic.player.domain.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -34,6 +35,7 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class PlayerDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(PlayerDao.class);

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PlaylistDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PlaylistDao.java
@@ -24,6 +24,7 @@ import org.airsonic.player.domain.Playlist;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -35,6 +36,7 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class PlaylistDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(PlaylistDao.class);

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
@@ -23,6 +23,7 @@ import org.airsonic.player.domain.PodcastChannel;
 import org.airsonic.player.domain.PodcastEpisode;
 import org.airsonic.player.domain.PodcastStatus;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -34,6 +35,7 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class PodcastDao extends AbstractDao {
 
     private static final String CHANNEL_INSERT_COLUMNS = "url, title, description, image_url, status, error_message";

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/RatingDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/RatingDao.java
@@ -22,6 +22,7 @@ package org.airsonic.player.dao;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,6 +34,7 @@ import java.util.Map;
  *
  * @author Sindre Mehus
  */
+@Repository("musicFileInfoDao")
 public class RatingDao extends AbstractDao {
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/ShareDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/ShareDao.java
@@ -22,6 +22,7 @@ package org.airsonic.player.dao;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.domain.Share;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -36,6 +37,7 @@ import java.util.Map;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class ShareDao extends AbstractDao {
 
     private static final String INSERT_COLUMNS = "name, description, username, created, expires, last_visited, visit_count";

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/TranscodingDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/TranscodingDao.java
@@ -23,6 +23,7 @@ import org.airsonic.player.domain.Transcoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -34,6 +35,7 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Repository
 public class TranscodingDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(TranscodingDao.class);

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
@@ -24,6 +24,7 @@ import org.airsonic.player.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -35,6 +36,7 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Repository
 @Transactional
 public class UserDao extends AbstractDao {
 

--- a/airsonic-main/src/main/java/org/airsonic/player/i18n/LocaleResolver.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/i18n/LocaleResolver.java
@@ -22,6 +22,8 @@ package org.airsonic.player.i18n;
 import org.airsonic.player.domain.UserSettings;
 import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.SettingsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -30,15 +32,17 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-
 /**
  * Locale resolver implementation which returns the locale selected in the settings.
  *
  * @author Sindre Mehus
  */
+@Service
 public class LocaleResolver implements org.springframework.web.servlet.LocaleResolver {
 
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private SettingsService settingsService;
     private Set<Locale> locales;
 

--- a/airsonic-main/src/main/java/org/airsonic/player/monitor/MetricsManager.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/monitor/MetricsManager.java
@@ -4,12 +4,14 @@ import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
 import org.airsonic.player.service.ApacheCommonsConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.concurrent.TimeUnit;
 
 /**
  * Created by remi on 17/01/17.
  */
+@Service
 public class MetricsManager {
 
     @Autowired

--- a/airsonic-main/src/main/java/org/airsonic/player/monitor/MetricsManager.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/monitor/MetricsManager.java
@@ -3,6 +3,7 @@ package org.airsonic.player.monitor;
 import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
 import org.airsonic.player.service.ApacheCommonsConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.concurrent.TimeUnit;
 
@@ -11,6 +12,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class MetricsManager {
 
+    @Autowired
     private ApacheCommonsConfigurationService configurationService;
 
     // Main metrics registry

--- a/airsonic-main/src/main/java/org/airsonic/player/service/ApacheCommonsConfigurationService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/ApacheCommonsConfigurationService.java
@@ -8,11 +8,13 @@ import org.apache.commons.configuration2.sync.ReadWriteSynchronizer;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 
+@Service
 public class ApacheCommonsConfigurationService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApacheCommonsConfigurationService.class);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/AudioScrobblerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/AudioScrobblerService.java
@@ -36,6 +36,8 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.*;
@@ -49,6 +51,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  *
  * @author Sindre Mehus
  */
+@Service
 public class AudioScrobblerService {
 
     private static final Logger LOG = LoggerFactory.getLogger(AudioScrobblerService.class);
@@ -57,6 +60,7 @@ public class AudioScrobblerService {
     private RegistrationThread thread;
     private final LinkedBlockingQueue<RegistrationData> queue = new LinkedBlockingQueue<RegistrationData>();
 
+    @Autowired
     private SettingsService settingsService;
     private final RequestConfig requestConfig = RequestConfig.custom()
             .setConnectTimeout(15000)

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JWTSecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JWTSecurityService.java
@@ -8,6 +8,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -16,6 +18,7 @@ import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.Date;
 
+@Service("jwtSecurityService")
 public class JWTSecurityService {
     private static final Logger logger = LoggerFactory.getLogger(JWTSecurityService.class);
 
@@ -25,6 +28,7 @@ public class JWTSecurityService {
     public static final int DEFAULT_DAYS_VALID_FOR = 7;
     private static SecureRandom secureRandom = new SecureRandom();
 
+    @Autowired
     private final SettingsService settingsService;
 
     public JWTSecurityService(SettingsService settingsService) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JWTSecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JWTSecurityService.java
@@ -28,9 +28,9 @@ public class JWTSecurityService {
     public static final int DEFAULT_DAYS_VALID_FOR = 7;
     private static SecureRandom secureRandom = new SecureRandom();
 
-    @Autowired
     private final SettingsService settingsService;
 
+    @Autowired
     public JWTSecurityService(SettingsService settingsService) {
         this.settingsService = settingsService;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxService.java
@@ -25,6 +25,8 @@ import org.airsonic.player.util.FileUtil;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
 
@@ -33,15 +35,21 @@ import java.io.InputStream;
  *
  * @author Sindre Mehus
  */
+@Service
 public class JukeboxService implements AudioPlayer.Listener {
 
     private static final Logger LOG = LoggerFactory.getLogger(JukeboxService.class);
 
     private AudioPlayer audioPlayer;
+    @Autowired
     private TranscodingService transcodingService;
+    @Autowired
     private AudioScrobblerService audioScrobblerService;
+    @Autowired
     private StatusService statusService;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private SecurityService securityService;
 
     private Player player;
@@ -49,6 +57,7 @@ public class JukeboxService implements AudioPlayer.Listener {
     private MediaFile currentPlayingFile;
     private float gain = AudioPlayer.DEFAULT_GAIN;
     private int offset;
+    @Autowired
     private MediaFileService mediaFileService;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/LastFmService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/LastFmService.java
@@ -32,6 +32,10 @@ import org.airsonic.player.domain.*;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,16 +49,21 @@ import java.util.regex.Pattern;
  * @author Sindre Mehus
  * @version $Id$
  */
+@Service
 public class LastFmService {
 
     private static final String LAST_FM_KEY = "ece4499898a9440896dfdce5dab26bbf";
     private static final long CACHE_TIME_TO_LIVE_MILLIS = 6 * 30 * 24 * 3600 * 1000L; // 6 months
     private static final Logger LOG = LoggerFactory.getLogger(LastFmService.class);
 
+    @Autowired
     private MediaFileDao mediaFileDao;
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private ArtistDao artistDao;
 
+    @PostConstruct
     public void init() {
         Caller caller = Caller.getInstance();
         caller.setUserAgent("Airsonic");

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -33,6 +33,8 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,16 +45,24 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Service
 public class MediaFileService {
 
     private static final Logger LOG = LoggerFactory.getLogger(MediaFileService.class);
 
+    @Autowired
     private Ehcache mediaFileMemoryCache;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private MediaFileDao mediaFileDao;
+    @Autowired
     private AlbumDao albumDao;
+    @Autowired
     private JaudiotaggerParser parser;
+    @Autowired
     private MetaDataParserFactory metaDataParserFactory;
     private boolean memoryCacheEnabled = true;
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -28,6 +28,10 @@ import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
 
 import java.io.File;
 import java.util.*;
@@ -37,6 +41,7 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Service
 public class MediaScannerService {
 
     private static final int INDEX_VERSION = 15;
@@ -46,15 +51,23 @@ public class MediaScannerService {
 
     private boolean scanning;
     private Timer timer;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private SearchService searchService;
+    @Autowired
     private PlaylistService playlistService;
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private MediaFileDao mediaFileDao;
+    @Autowired
     private ArtistDao artistDao;
+    @Autowired
     private AlbumDao albumDao;
     private int scanCount;
 
+    @PostConstruct
     public void init() {
         deleteOldIndexFiles();
         statistics = settingsService.getMediaLibraryStatistics();

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MusicIndexService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MusicIndexService.java
@@ -22,6 +22,8 @@ package org.airsonic.player.service;
 import org.airsonic.player.domain.*;
 import org.airsonic.player.domain.MusicIndex.SortableArtist;
 import org.airsonic.player.util.FileUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,9 +36,12 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
+@Service
 public class MusicIndexService {
 
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private MediaFileService mediaFileService;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/NetworkService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/NetworkService.java
@@ -22,6 +22,7 @@ package org.airsonic.player.service;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 import org.springframework.web.util.UrlPathHelper;
 
 import javax.servlet.http.HttpServletRequest;
@@ -31,7 +32,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-
+@Service
 public class NetworkService {
 
     private static UrlPathHelper urlPathHelper = new UrlPathHelper();

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlayerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlayerService.java
@@ -27,7 +27,11 @@ import org.airsonic.player.domain.User;
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Service;
 
+import javax.annotation.PostConstruct;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -42,16 +46,23 @@ import java.util.List;
  * @author Sindre Mehus
  * @see Player
  */
+@Service
+@DependsOn("liquibase")
 public class PlayerService {
 
     private static final String COOKIE_NAME = "player";
     private static final int COOKIE_EXPIRY = 365 * 24 * 3600; // One year
 
+    @Autowired
     private PlayerDao playerDao;
+    @Autowired
     private StatusService statusService;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private TranscodingService transcodingService;
 
+    @PostConstruct
     public void init() {
         playerDao.deleteOldPlayers(60);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistService.java
@@ -36,6 +36,8 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 import java.io.File;
@@ -50,14 +52,21 @@ import java.util.*;
  * @author Sindre Mehus
  * @see PlayQueue
  */
+@Service
 public class PlaylistService {
 
     private static final Logger LOG = LoggerFactory.getLogger(PlaylistService.class);
+    @Autowired
     private MediaFileDao mediaFileDao;
+    @Autowired
     private PlaylistDao playlistDao;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private List<PlaylistExportHandler> exportHandlers;
+    @Autowired
     private List<PlaylistImportHandler> importHandlers;
 
     public PlaylistService(

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -48,6 +48,10 @@ import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -63,6 +67,7 @@ import java.util.concurrent.*;
  *
  * @author Sindre Mehus
  */
+@Service
 public class PodcastService {
 
     private static final Logger LOG = LoggerFactory.getLogger(PodcastService.class);
@@ -76,10 +81,15 @@ public class PodcastService {
     private final ExecutorService downloadExecutor;
     private final ScheduledExecutorService scheduledExecutor;
     private ScheduledFuture<?> scheduledRefresh;
+    @Autowired
     private PodcastDao podcastDao;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private MetaDataParserFactory metaDataParserFactory;
 
     public PodcastService() {
@@ -95,6 +105,7 @@ public class PodcastService {
         scheduledExecutor = Executors.newSingleThreadScheduledExecutor(threadFactory);
     }
 
+    @PostConstruct
     public synchronized void init() {
         try {
             // Clean up partial downloads.

--- a/airsonic-main/src/main/java/org/airsonic/player/service/RatingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/RatingService.java
@@ -23,6 +23,8 @@ import org.airsonic.player.dao.RatingDao;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.util.FileUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -33,10 +35,14 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Service
 public class RatingService {
 
+    @Autowired
     private RatingDao ratingDao;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private MediaFileService mediaFileService;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SearchService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SearchService.java
@@ -47,6 +47,8 @@ import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,6 +65,7 @@ import static org.airsonic.player.service.SearchService.IndexType.*;
  * @version $Id$
  * @see MediaScannerService
  */
+@Service
 public class SearchService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SearchService.class);
@@ -80,8 +83,11 @@ public class SearchService {
     private static final Version LUCENE_VERSION = Version.LUCENE_30;
     private static final String LUCENE_DIR = "lucene2";
 
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private ArtistDao artistDao;
+    @Autowired
     private AlbumDao albumDao;
 
     private IndexWriter artistWriter;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -27,6 +27,7 @@ import org.airsonic.player.domain.User;
 import org.airsonic.player.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -34,6 +35,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
+import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -46,12 +48,16 @@ import java.util.List;
  *
  * @author Sindre Mehus
  */
+@Service
 public class SecurityService implements UserDetailsService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SecurityService.class);
 
+    @Autowired
     private UserDao userDao;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private Ehcache userCache;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -31,6 +31,10 @@ import org.airsonic.player.util.Util;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,11 +43,13 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+
 /**
  * Provides persistent storage of application settings and preferences.
  *
  * @author Sindre Mehus
  */
+@Service
 public class SettingsService {
 
     // Airsonic home directory.
@@ -210,10 +216,15 @@ public class SettingsService {
 
     private List<Theme> themes;
     private List<Locale> locales;
+    @Autowired
     private InternetRadioDao internetRadioDao;
+    @Autowired
     private MusicFolderDao musicFolderDao;
+    @Autowired
     private UserDao userDao;
+    @Autowired
     private AvatarDao avatarDao;
+    @Autowired
     private ApacheCommonsConfigurationService configurationService;
 
     private String[] cachedCoverArtFileTypesArray;
@@ -271,6 +282,7 @@ public class SettingsService {
      * Register in service locator so that non-Spring objects can access me.
      * This method is invoked automatically by Spring.
      */
+    @PostConstruct
     public void init() {
         logServerInfo();
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/ShareService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/ShareService.java
@@ -28,6 +28,8 @@ import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.http.HttpServletRequest;
@@ -43,13 +45,18 @@ import java.util.List;
  * @author Sindre Mehus
  * @see Share
  */
+@Service
 public class ShareService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ShareService.class);
 
+    @Autowired
     private ShareDao shareDao;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private JWTSecurityService jwtSecurityService;
 
     public List<Share> getAllShares() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SonosService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SonosService.java
@@ -37,6 +37,8 @@ import org.apache.cxf.jaxws.context.WrappedMessageContext;
 import org.apache.cxf.message.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.w3c.dom.Node;
 
 import javax.annotation.Resource;
@@ -60,6 +62,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
  * @author Sindre Mehus
  * @version $Id$
  */
+@Service
 public class SonosService implements SonosSoap {
 
     private static final Logger LOG = LoggerFactory.getLogger(SonosService.class);
@@ -92,11 +95,17 @@ public class SonosService implements SonosSoap {
     public static final String ID_SEARCH_ALBUMS = "search-albums";
     public static final String ID_SEARCH_SONGS = "search-songs";
 
+    @Autowired
     private SonosHelper sonosHelper;
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private SecurityService securityService;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private PlaylistService playlistService;
+    @Autowired
     private UPnPService upnpService;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
@@ -23,6 +23,8 @@ import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.PlayStatus;
 import org.airsonic.player.domain.Player;
 import org.airsonic.player.domain.TransferStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.util.*;
@@ -35,8 +37,10 @@ import java.util.*;
  * @author Sindre Mehus
  * @see TransferStatus
  */
+@Service
 public class StatusService {
 
+    @Autowired
     private MediaFileService mediaFileService;
 
     private final List<TransferStatus> streamStatuses = new ArrayList<TransferStatus>();

--- a/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
@@ -31,6 +31,8 @@ import org.apache.commons.io.filefilter.PrefixFileFilter;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -48,13 +50,17 @@ import java.util.List;
  * @author Sindre Mehus
  * @see TranscodeInputStream
  */
+@Service
 public class TranscodingService {
 
     private static final Logger LOG = LoggerFactory.getLogger(TranscodingService.class);
     public static final String FORMAT_RAW = "raw";
 
+    @Autowired
     private TranscodingDao transcodingDao;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private PlayerService playerService;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/UPnPService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/UPnPService.java
@@ -37,6 +37,11 @@ import org.fourthline.cling.support.model.dlna.DLNAProfiles;
 import org.fourthline.cling.support.model.dlna.DLNAProtocolInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -47,15 +52,20 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author Sindre Mehus
  * @version $Id$
  */
+@Service
 public class UPnPService {
 
     private static final Logger LOG = LoggerFactory.getLogger(UPnPService.class);
 
+    @Autowired
     private SettingsService settingsService;
     private UpnpService upnpService;
-    private CustomContentDirectory customContentDirectory;
+    @Autowired
+    @Qualifier("dispatchingContentDirectory")
+    private CustomContentDirectory dispatchingContentDirectory;
     private AtomicReference<Boolean> running = new AtomicReference<>(false);
 
+    @PostConstruct
     public void init() {
         if(settingsService.isDlnaEnabled() || settingsService.isSonosEnabled()) {
             ensureServiceStarted();
@@ -152,7 +162,7 @@ public class UPnPService {
 
             @Override
             protected CustomContentDirectory createServiceInstance() throws Exception {
-                return customContentDirectory;
+                return dispatchingContentDirectory;
             }
         });
 
@@ -206,6 +216,6 @@ public class UPnPService {
     }
 
     public void setCustomContentDirectory(CustomContentDirectory customContentDirectory) {
-        this.customContentDirectory = customContentDirectory;
+        this.dispatchingContentDirectory = customContentDirectory;
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
@@ -30,6 +30,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -52,6 +53,7 @@ import java.util.regex.Pattern;
  *
  * @author Sindre Mehus
  */
+@Service
 public class VersionService {
 
     private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/DefaultMetaDataParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/DefaultMetaDataParser.java
@@ -21,6 +21,8 @@ package org.airsonic.player.service.metadata;
 
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.service.SettingsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 
@@ -29,8 +31,10 @@ import java.io.File;
  *
  * @author Sindre Mehus
  */
+@Service
 public class DefaultMetaDataParser extends MetaDataParser {
 
+    @Autowired
     private final SettingsService settingsService;
 
     public DefaultMetaDataParser(SettingsService settingsService) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
@@ -27,6 +27,8 @@ import org.airsonic.player.util.StringUtil;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.InputStream;
@@ -40,6 +42,7 @@ import java.util.regex.Pattern;
  *
  * @author Sindre Mehus
  */
+@Service("ffmpegParser")
 public class FFmpegParser extends MetaDataParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(FFmpegParser.class);
@@ -48,7 +51,9 @@ public class FFmpegParser extends MetaDataParser {
     private static final Pattern DIMENSION_PATTERN = Pattern.compile("Video.*?, (\\d+)x(\\d+)");
     private static final Pattern PAR_PATTERN = Pattern.compile("PAR (\\d+):(\\d+)");
 
+    @Autowired
     private TranscodingService transcodingService;
+    @Autowired
     private SettingsService settingsService;
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -32,6 +32,8 @@ import org.jaudiotagger.tag.images.Artwork;
 import org.jaudiotagger.tag.reference.GenreTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.util.SortedSet;
@@ -46,12 +48,14 @@ import java.util.regex.Pattern;
  *
  * @author Sindre Mehus
  */
+@Service
 public class JaudiotaggerParser extends MetaDataParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(JaudiotaggerParser.class);
     private static final Pattern GENRE_PATTERN = Pattern.compile("\\((\\d+)\\).*");
     private static final Pattern TRACK_NUMBER_PATTERN = Pattern.compile("(\\d+)/\\d+");
     private static final Pattern YEAR_NUMBER_PATTERN = Pattern.compile("(\\d{4}).*");
+    @Autowired
     private final SettingsService settingsService;
 
     public JaudiotaggerParser(SettingsService settingsService) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/sonos/SonosHelper.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/sonos/SonosHelper.java
@@ -29,6 +29,8 @@ import org.airsonic.player.domain.*;
 import org.airsonic.player.service.*;
 import org.airsonic.player.util.StringUtil;
 import org.airsonic.player.util.Util;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -40,20 +42,32 @@ import static org.airsonic.player.service.NetworkService.getBaseUrl;
  * @author Sindre Mehus
  * @version $Id$
  */
+@Service
 public class SonosHelper {
 
     public static final String AIRSONIC_CLIENT_ID = "sonos";
 
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private PlaylistService playlistService;
+    @Autowired
     private PlayerService playerService;
+    @Autowired
     private TranscodingService transcodingService;
+    @Autowired
     private SettingsService settingsService;
+    @Autowired
     private MusicIndexService musicIndexService;
+    @Autowired
     private SearchService searchService;
+    @Autowired
     private MediaFileDao mediaFileDao;
+    @Autowired
     private RatingService ratingService;
+    @Autowired
     private LastFmService lastFmService;
+    @Autowired
     private PodcastService podcastService;
 
     public List<AbstractMedia> forRoot() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
@@ -33,6 +33,7 @@ import org.fourthline.cling.support.model.SortCriterion;
 import org.fourthline.cling.support.model.container.Container;
 import org.fourthline.cling.support.model.container.MusicAlbum;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -43,6 +44,7 @@ import java.util.List;
  * @author Allen Petersen
  * @version $Id$
  */
+@Service
 public class AlbumUpnpProcessor extends UpnpContentProcessor <Album, MediaFile> {
 
     public static final String ALL_BY_ARTIST = "allByArtist";

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/ArtistUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/ArtistUpnpProcessor.java
@@ -28,6 +28,7 @@ import org.fourthline.cling.support.model.DIDLContent;
 import org.fourthline.cling.support.model.container.Container;
 import org.fourthline.cling.support.model.container.MusicArtist;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
@@ -35,6 +36,7 @@ import java.util.List;
  * @author Allen Petersen
  * @version $Id$
  */
+@Service
 public class ArtistUpnpProcessor extends UpnpContentProcessor <Artist, Album> {
 
     @Autowired

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/CustomContentDirectory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/CustomContentDirectory.java
@@ -37,6 +37,7 @@ import org.fourthline.cling.support.model.DIDLContent;
 import org.fourthline.cling.support.model.Res;
 import org.fourthline.cling.support.model.SortCriterion;
 import org.seamless.util.MimeType;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -47,9 +48,13 @@ public abstract class CustomContentDirectory extends AbstractContentDirectorySer
 
     protected static final String CONTAINER_ID_ROOT = "0";
 
+    @Autowired
     protected SettingsService settingsService;
+    @Autowired
     private PlayerService playerService;
+    @Autowired
     private TranscodingService transcodingService;
+    @Autowired
     protected JWTSecurityService jwtSecurityService;
 
     public CustomContentDirectory() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/DispatchingContentDirectory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/DispatchingContentDirectory.java
@@ -30,6 +30,7 @@ import org.fourthline.cling.support.model.item.MusicTrack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -41,6 +42,7 @@ import java.util.Arrays;
  * @author Sindre Mehus
  * @version $Id$
  */
+@Service
 public class DispatchingContentDirectory extends CustomContentDirectory {
 
     public static final Logger LOG = LoggerFactory.getLogger(DispatchingContentDirectory.class);
@@ -61,9 +63,11 @@ public class DispatchingContentDirectory extends CustomContentDirectory {
     @Autowired
     private MediaFileUpnpProcessor mediaFileProcessor;
     //@Autowired can't autowire because of the subclassing :P
-    private AlbumUpnpProcessor albumProcessor;
+    @Autowired//first checks type then field name to autowire
+    private AlbumUpnpProcessor albumUpnpProcessor;
     //@Autowired can't autowire because of the subclassing :P
-    private RecentAlbumUpnpProcessor recentAlbumProcessor;
+    @Autowired//first checks type then field name to autowire
+    private RecentAlbumUpnpProcessor recentAlbumUpnpProcessor;
     @Autowired
     private ArtistUpnpProcessor artistProcessor;
     @Autowired
@@ -73,7 +77,7 @@ public class DispatchingContentDirectory extends CustomContentDirectory {
 
     @Autowired
     private MediaFileService mediaFileService;
-
+    @Autowired
     private PlaylistService playlistService;
 
     @Autowired
@@ -211,17 +215,17 @@ public class DispatchingContentDirectory extends CustomContentDirectory {
     }
 
     public AlbumUpnpProcessor getAlbumProcessor() {
-        return albumProcessor;
+        return albumUpnpProcessor;
     }
     public void setAlbumProcessor(AlbumUpnpProcessor albumProcessor) {
-        this.albumProcessor = albumProcessor;
+        this.albumUpnpProcessor = albumProcessor;
     }
 
     public RecentAlbumUpnpProcessor getRecentAlbumProcessor() {
-        return recentAlbumProcessor;
+        return recentAlbumUpnpProcessor;
     }
     public void setRecentAlbumProcessor(RecentAlbumUpnpProcessor recentAlbumProcessor) {
-        this.recentAlbumProcessor = recentAlbumProcessor;
+        this.recentAlbumUpnpProcessor = recentAlbumProcessor;
     }
 
     public ArtistUpnpProcessor getArtistProcessor() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/FolderBasedContentDirectory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/FolderBasedContentDirectory.java
@@ -34,6 +34,8 @@ import org.fourthline.cling.support.model.item.Item;
 import org.fourthline.cling.support.model.item.MusicTrack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -45,13 +47,16 @@ import java.util.List;
  * @author Sindre Mehus
  * @version $Id$
  */
+@Service
 public class FolderBasedContentDirectory extends CustomContentDirectory {
 
     private static final Logger LOG = LoggerFactory.getLogger(FolderBasedContentDirectory.class);
     private static final String CONTAINER_ID_PLAYLIST_ROOT = "playlists";
     private static final String CONTAINER_ID_PLAYLIST_PREFIX = "playlist-";
     private static final String CONTAINER_ID_FOLDER_PREFIX = "folder-";
+    @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
     private PlaylistService playlistService;
 
     @Override

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/GenreUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/GenreUpnpProcessor.java
@@ -28,6 +28,7 @@ import org.fourthline.cling.support.model.DIDLContent;
 import org.fourthline.cling.support.model.SortCriterion;
 import org.fourthline.cling.support.model.container.Container;
 import org.fourthline.cling.support.model.container.GenreContainer;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
@@ -35,6 +36,7 @@ import java.util.List;
  * @author Allen Petersen
  * @version $Id$
  */
+@Service
 public class GenreUpnpProcessor extends UpnpContentProcessor <Genre, MediaFile> {
 
     public GenreUpnpProcessor() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/MediaFileUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/MediaFileUpnpProcessor.java
@@ -31,6 +31,7 @@ import org.fourthline.cling.support.model.container.MusicAlbum;
 import org.fourthline.cling.support.model.item.Item;
 import org.fourthline.cling.support.model.item.MusicTrack;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -41,6 +42,7 @@ import java.util.List;
  * @author Allen Petersen
  * @version $Id$
  */
+@Service
 public class MediaFileUpnpProcessor extends UpnpContentProcessor <MediaFile, MediaFile> {
 
     @Autowired

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/RecentAlbumUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/RecentAlbumUpnpProcessor.java
@@ -20,6 +20,7 @@
 package org.airsonic.player.service.upnp;
 import org.airsonic.player.domain.Album;
 import org.airsonic.player.domain.MusicFolder;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
@@ -27,6 +28,7 @@ import java.util.List;
  * @author Allen Petersen
  * @version $Id$
  */
+@Service
 public class RecentAlbumUpnpProcessor extends AlbumUpnpProcessor {
     private final static int RECENT_COUNT = 50;
 

--- a/airsonic-main/src/main/resources/applicationContext-service.xml
+++ b/airsonic-main/src/main/resources/applicationContext-service.xml
@@ -11,11 +11,14 @@
 
     <!-- DAO's -->
     
-    <context:component-scan base-package="org.airsonic.player.dao" />
+    <context:component-scan base-package="org.airsonic.player.dao, 
+        org.airsonic.player.service, 
+        org.airsonic.player.monitor, 
+        org.airsonic.player.ajax, 
+        org.airsonic.player.i18n." />
 
     <!-- Services -->
 
-    <context:component-scan base-package="org.airsonic.player.service" />
     <bean id="metaDataParserFactory" class="org.airsonic.player.service.metadata.MetaDataParserFactory">
         <property name="parsers">
             <list>
@@ -25,75 +28,7 @@
             </list>
         </property>
     </bean>
-    <bean id="metricsManager" class="org.airsonic.player.monitor.MetricsManager"></bean>
 
     <!-- AJAX services -->
-
-    <bean id="ajaxMultiService" class="org.airsonic.player.ajax.MultiService">
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="settingsService" ref="settingsService"/>
-        <property name="securityService" ref="securityService"/>
-        <property name="lastFmService" ref="lastFmService"/>
-    </bean>
-
-    <bean id="ajaxNowPlayingService" class="org.airsonic.player.ajax.NowPlayingService">
-        <property name="playerService" ref="playerService"/>
-        <property name="statusService" ref="statusService"/>
-        <property name="settingsService" ref="settingsService"/>
-        <property name="mediaScannerService" ref="mediaScannerService"/>
-    </bean>
-
-    <bean id="ajaxPlayQueueService" class="org.airsonic.player.ajax.PlayQueueService">
-        <property name="playerService" ref="playerService"/>
-        <property name="playlistService" ref="playlistService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="lastFmService" ref="lastFmService"/>
-        <property name="mediaFileDao" ref="mediaFileDao"/>
-        <property name="playQueueDao" ref="playQueueDao"/>
-        <property name="jukeboxService" ref="jukeboxService"/>
-        <property name="transcodingService" ref="transcodingService"/>
-        <property name="settingsService" ref="settingsService"/>
-        <property name="searchService" ref="searchService"/>
-        <property name="ratingService" ref="ratingService"/>
-        <property name="securityService" ref="securityService"/>
-        <property name="podcastService" ref="podcastService"/>
-        <property name="jwtSecurityService" ref="jwtSecurityService" />
-    </bean>
-
-    <bean id="ajaxPlaylistService" class="org.airsonic.player.ajax.PlaylistService">
-        <property name="playlistService" ref="playlistService"/>
-        <property name="securityService" ref="securityService"/>
-        <property name="settingsService" ref="settingsService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="playerService" ref="playerService"/>
-        <property name="mediaFileDao" ref="mediaFileDao"/>
-        <property name="localeResolver" ref="localeResolver"/>
-    </bean>
-
-    <bean id="ajaxLyricsService" class="org.airsonic.player.ajax.LyricsService"/>
-
-    <bean id="ajaxCoverArtService" class="org.airsonic.player.ajax.CoverArtService">
-        <property name="securityService" ref="securityService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="lastFmService" ref="lastFmService"/>
-    </bean>
-
-    <bean id="ajaxStarService" class="org.airsonic.player.ajax.StarService">
-        <property name="securityService" ref="securityService"/>
-        <property name="mediaFileDao" ref="mediaFileDao"/>
-    </bean>
-
-    <bean id="ajaxTagService" class="org.airsonic.player.ajax.TagService">
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="metaDataParserFactory" ref="metaDataParserFactory"/>
-    </bean>
-
-    <bean id="ajaxTransferService" class="org.airsonic.player.ajax.TransferService"/>
-
-    <bean id="localeResolver" class="org.airsonic.player.i18n.LocaleResolver">
-        <property name="securityService" ref="securityService"/>
-        <property name="settingsService" ref="settingsService"/>
-    </bean>
-
 
 </beans>

--- a/airsonic-main/src/main/resources/applicationContext-service.xml
+++ b/airsonic-main/src/main/resources/applicationContext-service.xml
@@ -10,253 +10,22 @@
     <import resource="applicationContext-db.xml" />
 
     <!-- DAO's -->
-
-    <bean id="playerDao" class="org.airsonic.player.dao.PlayerDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="mediaFileDao" class="org.airsonic.player.dao.MediaFileDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="artistDao" class="org.airsonic.player.dao.ArtistDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="albumDao" class="org.airsonic.player.dao.AlbumDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="playlistDao" class="org.airsonic.player.dao.PlaylistDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="playQueueDao" class="org.airsonic.player.dao.PlayQueueDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="internetRadioDao" class="org.airsonic.player.dao.InternetRadioDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="musicFileInfoDao" class="org.airsonic.player.dao.RatingDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="musicFolderDao" class="org.airsonic.player.dao.MusicFolderDao">
-        <property name="daoHelper" ref="daoHelper"/>
-        <property name="userDao" ref="userDao" />
-    </bean>
-
-    <bean id="userDao" class="org.airsonic.player.dao.UserDao">
-        <property name="daoHelper" ref="daoHelper"/>
-        <property name="userTableQuote" ref="userTableQuote"/>
-    </bean>
-
-    <bean id="transcodingDao" class="org.airsonic.player.dao.TranscodingDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="podcastDao" class="org.airsonic.player.dao.PodcastDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="avatarDao" class="org.airsonic.player.dao.AvatarDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="shareDao" class="org.airsonic.player.dao.ShareDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
-
-    <bean id="bookmarkDao" class="org.airsonic.player.dao.BookmarkDao">
-        <property name="daoHelper" ref="daoHelper"/>
-    </bean>
+    
+    <context:component-scan base-package="org.airsonic.player.dao" />
 
     <!-- Services -->
 
-    <bean id="mediaFileService" class="org.airsonic.player.service.MediaFileService">
-        <property name="securityService" ref="securityService"/>
-        <property name="settingsService" ref="settingsService"/>
-        <property name="mediaFileMemoryCache" ref="mediaFileMemoryCache"/>
-        <property name="mediaFileDao" ref="mediaFileDao"/>
-        <property name="albumDao" ref="albumDao"/>
-        <property name="metaDataParserFactory" ref="metaDataParserFactory"/>
-        <property name="parser" ref="jaudiotaggerParser" />
-    </bean>
-
-    <bean id="securityService" class="org.airsonic.player.service.SecurityService">
-        <property name="settingsService" ref="settingsService"/>
-        <property name="userDao" ref="userDao"/>
-        <property name="userCache" ref="userCache"/>
-    </bean>
-
-    <bean id="configurationService" class="org.airsonic.player.service.ApacheCommonsConfigurationService" />
-
-    <bean id="metricsManager" class="org.airsonic.player.monitor.MetricsManager">
-        <property name="configurationService" ref="configurationService" />
-    </bean>
-
-    <bean id="settingsService" class="org.airsonic.player.service.SettingsService" init-method="init">
-        <property name="internetRadioDao" ref="internetRadioDao"/>
-        <property name="musicFolderDao" ref="musicFolderDao"/>
-        <property name="userDao" ref="userDao"/>
-        <property name="avatarDao" ref="avatarDao"/>
-        <property name="configurationService" ref="configurationService" />
-    </bean>
-
-    <bean id="mediaScannerService" class="org.airsonic.player.service.MediaScannerService" init-method="init" depends-on="metaDataParserFactory">
-        <property name="settingsService" ref="settingsService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="mediaFileDao" ref="mediaFileDao"/>
-        <property name="playlistService" ref="playlistService"/>
-        <property name="artistDao" ref="artistDao"/>
-        <property name="albumDao" ref="albumDao"/>
-        <property name="searchService" ref="searchService"/>
-    </bean>
-
-    <bean id="searchService" class="org.airsonic.player.service.SearchService">
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="artistDao" ref="artistDao"/>
-        <property name="albumDao" ref="albumDao"/>
-    </bean>
-
-    <bean id="networkService" class="org.airsonic.player.service.NetworkService" />
-
-    <bean id="playerService"
-          class="org.airsonic.player.service.PlayerService"
-          init-method="init"
-          depends-on="liquibase">
-        <property name="playerDao" ref="playerDao"/>
-        <property name="statusService" ref="statusService"/>
-        <property name="securityService" ref="securityService"/>
-        <property name="transcodingService" ref="transcodingService"/>
-    </bean>
-
-    <context:component-scan base-package="org.airsonic.player.service.playlist" />
-
-    <!--suppress SpringBeanConstructorArgInspection, AutowiredDependenciesInspection -->
-    <bean id="playlistService" class="org.airsonic.player.service.PlaylistService" autowire="constructor"/>
-
-    <bean id="versionService" class="org.airsonic.player.service.VersionService" />
-
-    <bean id="statusService" class="org.airsonic.player.service.StatusService">
-        <property name="mediaFileService" ref="mediaFileService"/>
-    </bean>
-
-    <bean id="ratingService" class="org.airsonic.player.service.RatingService">
-        <property name="ratingDao" ref="musicFileInfoDao"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="securityService" ref="securityService"/>
-    </bean>
-
-    <bean id="musicIndexService" class="org.airsonic.player.service.MusicIndexService">
-        <property name="settingsService" ref="settingsService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-    </bean>
-
-    <bean id="audioScrobblerService" class="org.airsonic.player.service.AudioScrobblerService">
-        <property name="settingsService" ref="settingsService"/>
-    </bean>
-
-    <bean id="transcodingService" class="org.airsonic.player.service.TranscodingService">
-        <property name="transcodingDao" ref="transcodingDao"/>
-        <property name="settingsService" ref="settingsService"/>
-        <property name="playerService" ref="playerService"/>
-    </bean>
-
-    <bean id="shareService" class="org.airsonic.player.service.ShareService">
-        <property name="shareDao" ref="shareDao"/>
-        <property name="securityService" ref="securityService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="jwtSecurityService" ref="jwtSecurityService" />
-    </bean>
-
-    <bean id="podcastService" class="org.airsonic.player.service.PodcastService" init-method="init">
-        <property name="podcastDao" ref="podcastDao"/>
-        <property name="settingsService" ref="settingsService"/>
-        <property name="securityService" ref="securityService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="metaDataParserFactory" ref="metaDataParserFactory"/>
-    </bean>
-
-    <bean id="jukeboxService" class="org.airsonic.player.service.JukeboxService">
-        <property name="statusService" ref="statusService"/>
-        <property name="transcodingService" ref="transcodingService"/>
-        <property name="audioScrobblerService" ref="audioScrobblerService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="settingsService" ref="settingsService"/>
-        <property name="securityService" ref="securityService"/>
-    </bean>
-
-    <bean id="folderBasedContentDirectory" class="org.airsonic.player.service.upnp.FolderBasedContentDirectory">
-        <property name="settingsService" ref="settingsService"/>
-        <property name="playlistService" ref="playlistService"/>
-        <property name="playerService" ref="playerService"/>
-        <property name="transcodingService" ref="transcodingService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="jwtSecurityService" ref="jwtSecurityService" />
-    </bean>
-
-    <bean id="dispatchingContentDirectory" class="org.airsonic.player.service.upnp.DispatchingContentDirectory">
-        <property name="settingsService" ref="settingsService"/>
-        <property name="playlistService" ref="playlistService"/>
-        <property name="playerService" ref="playerService"/>
-        <property name="transcodingService" ref="transcodingService"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="jwtSecurityService" ref="jwtSecurityService" />
-        <property name="albumProcessor" ref="albumUpnpProcessor" />
-        <property name="recentAlbumProcessor" ref="recentAlbumUpnpProcessor" />
-    </bean>
-
-    <bean id="mediaFileUpnpProcessor" class="org.airsonic.player.service.upnp.MediaFileUpnpProcessor"/>
-    <bean id="playlistUpnpProcessor" class="org.airsonic.player.service.upnp.PlaylistUpnpProcessor"/>
-    <bean id="rootUpnpProcessor" class="org.airsonic.player.service.upnp.RootUpnpProcessor"/>
-    <bean id="artistUpnpProcessor" class="org.airsonic.player.service.upnp.ArtistUpnpProcessor"/>
-    <bean id="albumUpnpProcessor" class="org.airsonic.player.service.upnp.AlbumUpnpProcessor"/>
-    <bean id="recentAlbumUpnpProcessor" class="org.airsonic.player.service.upnp.RecentAlbumUpnpProcessor"/>
-    <bean id="genreUpnpProcessor" class="org.airsonic.player.service.upnp.GenreUpnpProcessor"/>
-
-    <bean id="upnpService" class="org.airsonic.player.service.UPnPService" init-method="init">
-        <property name="settingsService" ref="settingsService"/>
-        <property name="customContentDirectory" ref="dispatchingContentDirectory"/>
-    </bean>
-
-    <bean id="lastFmService" class="org.airsonic.player.service.LastFmService" init-method="init">
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="mediaFileDao" ref="mediaFileDao"/>
-        <property name="artistDao" ref="artistDao"/>
-    </bean>
-
-    <bean id="sonosService" class="org.airsonic.player.service.SonosService">
-        <property name="sonosHelper" ref="sonosHelper"/>
-        <property name="mediaFileService" ref="mediaFileService"/>
-        <property name="securityService" ref="securityService"/>
-        <property name="settingsService" ref="settingsService"/>
-        <property name="playlistService" ref="playlistService"/>
-        <property name="upnpService" ref="upnpService"/>
-    </bean>
-
-    <bean id="jaudiotaggerParser" class="org.airsonic.player.service.metadata.JaudiotaggerParser">
-        <constructor-arg name="settingsService" ref="settingsService" />
-    </bean>
-
+    <context:component-scan base-package="org.airsonic.player.service" />
     <bean id="metaDataParserFactory" class="org.airsonic.player.service.metadata.MetaDataParserFactory">
         <property name="parsers">
             <list>
-                <bean class="org.airsonic.player.service.metadata.JaudiotaggerParser">
-                    <constructor-arg name="settingsService" ref="settingsService" />
-                </bean>
-                <bean class="org.airsonic.player.service.metadata.FFmpegParser">
-                    <property name="transcodingService" ref="transcodingService"/>
-                    <property name="settingsService" ref="settingsService" />
-                </bean>
-                <bean class="org.airsonic.player.service.metadata.DefaultMetaDataParser">
-                    <constructor-arg name="settingsService" ref="settingsService" />
-                </bean>
+                <ref bean="jaudiotaggerParser" />
+                <ref bean="ffmpegParser" />
+                <ref bean="defaultMetaDataParser" />
             </list>
         </property>
     </bean>
+    <bean id="metricsManager" class="org.airsonic.player.monitor.MetricsManager"></bean>
 
     <!-- AJAX services -->
 
@@ -326,8 +95,5 @@
         <property name="settingsService" ref="settingsService"/>
     </bean>
 
-    <bean id="jwtSecurityService" class="org.airsonic.player.service.JWTSecurityService">
-        <constructor-arg ref="settingsService" />
-    </bean>
 
 </beans>


### PR DESCRIPTION
This change was to make all the dao and service type classes use autowired and be component scanned. It simplifies the applicationContext-service.xml down to a few lines. I like this method of working with data access layers and services its easy to make a new service or dao and right away be able to use it in another service.



Guidelines for Contributing
---------------------------

Airsonic development is a community project, and contributions are welcomed. Here are a few guidelines you should follow before submitting:

  1.  **License Acceptance** All contributions must be licensed as [GNU GPLv3](https://github.com/airsonic/airsonic/blob/develop/LICENSE.txt) to be accepted. Use [`git commit --signoff`](https://jk.gs/git-commit.html) to acknowledge this.
  2.  **No Breakage** New features or changes to existing ones must not degrade the user experience. This means do not introduce bugs, remove functionality, or make large changes to existing themes/UI without prior discussion in an Issue.
  3.  **Coding standards** Language best-practices should be followed, comment generously, and avoid "clever" algorithms. Refactoring existing messes is great, but watch out for breakage.
  4.  **Be bold!** Without contributions, this project will vanish. If you just want to help out, try [submiting a patch](https://github.com/airsonic/airsonic/issues?q=is%3Aissue+is%3Aopen+label%3Apatches-welcome) for an open Issue.
  5.  **Stay relevant** Issues or commentary that is off-topic or tangential to Airsonic development is subject to moderation. Questions should be focused on improving documentation to solve a problem. Visit [Reddit](https://www.reddit.com/r/airsonic) or [IRC](http://webchat.freenode.net?channels=%23airsonic) for community discussion.
