### PR TITLE
Fix error message readability #535

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -1,19 +1,21 @@
 <%@ page language="java" contentType="text/html; charset=utf-8" pageEncoding="UTF-8" isErrorPage="true" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 
 
 <html><head>
+     <%@ include file="head.jsp" %>
     <!--[if lt IE 7.]>
     <script defer type="text/javascript" src="script/pngfix.js"></script>
     <![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <link rel="stylesheet" href="style/default.css" type="text/css"/>
+
 </head>
 
-<body>
+<body class="mainframe bgcolor1">
 <h1>
-    <img src="icons/default_light/error.png" alt=""/>
+    <img src="<spring:theme code="errorImage"/>" alt=""/>
     <span style="vertical-align: middle">Error</span>
 </h1>
 


### PR DESCRIPTION
This pull request addresses #535. The fix basically consists of including` head.jsp` in `error.jsp`. 

![image](https://user-images.githubusercontent.com/5294464/29895026-d51d6df6-8dd7-11e7-8f28-0abd50de43e4.png)

This has been tested with a couple of other themes (including Default, Midnight, Barent Sea and  Groove)