### PR TITLE
Initial setup of rest api

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -475,6 +475,32 @@
             <version>2.1.0</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-mockmvc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -548,7 +574,31 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>generate-docs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html</backend>
+                            <doctype>book</doctype>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.restdocs</groupId>
+                        <artifactId>spring-restdocs-asciidoctor</artifactId>
+                        <version>1.2.1.RELEASE</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/airsonic-main/src/main/asciidoc/api-guide.adoc
+++ b/airsonic-main/src/main/asciidoc/api-guide.adoc
@@ -1,0 +1,109 @@
+= Airsonic REST API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+:operation-curl-request-title: Example request
+:operation-http-response-title: Example response
+
+[[overview]]
+= Overview
+
+[[overview-http-verbs]]
+== HTTP verbs
+
+RESTful notes tries to adhere as closely as possible to standard HTTP and REST conventions in its
+use of HTTP verbs.
+
+|===
+| Verb | Usage
+
+| `GET`
+| Used to retrieve a resource
+
+| `POST`
+| Used to create a new resource
+
+| `PATCH`
+| Used to update an existing resource, including partial updates
+
+| `DELETE`
+| Used to delete an existing resource
+|===
+
+[[overview-http-status-codes]]
+== HTTP status codes
+
+RESTful notes tries to adhere as closely as possible to standard HTTP and REST conventions in its
+use of HTTP status codes.
+
+|===
+| Status code | Usage
+
+| `200 OK`
+| The request completed successfully with response data
+
+| `201 Created`
+| A new resource has been created successfully. The resource's URI is available from the response's
+`Location` header
+
+| `204 No Content`
+| The request completed successfully with no response data
+
+| `400 Bad Request`
+| The request was malformed. The response body will include an error providing further information
+
+| `404 Not Found`
+| The requested resource did not exist
+|===
+
+[[overview-errors]]
+== Errors
+
+Whenever an error response (status code >= 400) is returned, the body will contain a JSON object
+that describes the problem. The error object has the following structure:
+
+include::{snippets}/error-example/response-fields.adoc[]
+
+For example, a request that attempts to apply a non-existent tag to a note will produce a
+`400 Bad Request` response:
+
+include::{snippets}/error-example/http-response.adoc[]
+
+[[overview-hypermedia]]
+== Hypermedia
+
+RESTful Notes uses hypermedia and resources include links to other resources in their
+responses. Responses are in http://stateless.co/hal_specification.html[Hypertext Application
+from resource to resource.
+Language (HAL)] format. Links can be found beneath the `_links` key. Users of the API should
+not create URIs themselves, instead they should use the above-described links to navigate
+
+[[resources]]
+= Resources
+
+
+[[resources-index]]
+== Index
+
+The index provides the entry point into the service and also allows testing
+api availability.
+
+[[resources-index-access]]
+=== Accessing the index
+
+A `GET` request is used to access the index
+
+operation::index-example[snippets='curl-request,http-response']
+
+[[resources-music-folders]]
+== Music Folders
+
+Provides interaction with music folders for the current authenticated user.
+
+[[resources-music-folders-access]]
+=== Listing Music Folders
+
+operation::music-folders-list-example[snippets='curl-request,response-fields,http-response']

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/LeftController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/LeftController.java
@@ -66,9 +66,10 @@ public class LeftController  {
 
     /**
      * Note: This class intentionally does not implement org.springframework.web.servlet.mvc.LastModified
-     * as we don't need browser-side caching of left.jsp.  This method is only used by RESTController.
+     * as we don't need browser-side caching of left.jsp.  This method is only used by SubsonicRESTController and
+     * RESTController.
      */
-    long getLastModified(HttpServletRequest request) {
+    public long getLastModified(HttpServletRequest request) {
         saveSelectedMusicFolder(request);
 
         if (mediaScannerService.isScanning()) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/api/IndexRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/api/IndexRESTController.java
@@ -1,0 +1,21 @@
+package org.airsonic.player.controller.api;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Controller
+@RequestMapping(value = "/api")
+public class IndexRESTController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IndexRESTController.class);
+
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity<Void> index() {
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/api/JsonpAdvice.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/api/JsonpAdvice.java
@@ -1,0 +1,12 @@
+package org.airsonic.player.controller.api;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.AbstractJsonpResponseBodyAdvice;
+
+@ControllerAdvice
+public class JsonpAdvice extends AbstractJsonpResponseBodyAdvice {
+
+    public JsonpAdvice() {
+        super("callback");
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/api/MusicFolderRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/api/MusicFolderRESTController.java
@@ -1,0 +1,55 @@
+/*
+ This file is part of Libresonic.
+
+ Libresonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Libresonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Libresonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2016 (C) Libresonic Authors
+ Based upon Subsonic, Copyright 2009 (C) Sindre Mehus
+ */
+package org.airsonic.player.controller.api;
+
+import org.airsonic.player.domain.MusicFolder;
+import org.airsonic.player.service.SecurityService;
+import org.airsonic.player.service.SettingsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.List;
+
+@Controller
+@RequestMapping(value = "/api/musicFolders")
+public class MusicFolderRESTController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MusicFolderRESTController.class);
+
+    @Autowired
+    private SettingsService settingsService;
+    @Autowired
+    private SecurityService securityService;
+
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity<List<MusicFolder>> getMusicFolders(HttpServletRequest request) throws Exception {
+        String username = securityService.getCurrentUsername(request);
+        List<MusicFolder> musicFoldersForUser = settingsService.getMusicFoldersForUser(username);
+
+        return ResponseEntity.ok(musicFoldersForUser);
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/api/BaseRESTControllerTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/api/BaseRESTControllerTestCase.java
@@ -1,0 +1,88 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2016 (C) Airsonic Authors
+ Based upon Subsonic, Copyright 2009 (C) Sindre Mehus
+ */
+package org.airsonic.player.controller.api;
+
+import org.airsonic.player.Application;
+import org.airsonic.player.TestCaseUtils;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.JUnitRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.io.IOException;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+// TODO fix jsp/jar scanning
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class)
+public class BaseRESTControllerTestCase {
+
+    // TODO why didnt the home rule work here?
+    static {
+        System.setProperty("airsonic.home", TestCaseUtils.airsonicHomePathForTest());
+
+        try {
+            TestCaseUtils.cleanAirsonicHomeForTest();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @ClassRule
+    public static final SpringClassRule classRule = new SpringClassRule();
+
+    @Rule
+    public final SpringMethodRule springMethodRule = new SpringMethodRule();
+
+    @Rule
+    public JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation("target/generated-snippets");
+
+    MockMvc mockMvc;
+
+    RestDocumentationResultHandler documentationHandler;
+
+    @Autowired
+    protected WebApplicationContext context;
+
+    @Before
+    public void setUp() {
+        this.documentationHandler = document("{method-name}",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()));
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
+                .apply(documentationConfiguration(this.restDocumentation))
+                .alwaysDo(this.documentationHandler)
+                .alwaysDo(print())
+                .build();
+    }
+
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/api/MusicFolderRESTControllerTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/api/MusicFolderRESTControllerTestCase.java
@@ -1,0 +1,88 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2016 (C) Airsonic Authors
+ Based upon Subsonic, Copyright 2009 (C) Sindre Mehus
+ */
+package org.airsonic.player.controller.api;
+
+import org.airsonic.player.domain.MusicFolder;
+import org.airsonic.player.service.SettingsService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.Date;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WithMockUser(username = "admin", password = "admin")
+public class MusicFolderRESTControllerTestCase extends BaseRESTControllerTestCase {
+
+    @Autowired
+    SettingsService settingsService;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        super.setUp();
+
+        MusicFolder testFolder = new MusicFolder(null, temporaryFolder.getRoot(), "testFolder", true, new Date());
+        settingsService.createMusicFolder(testFolder);
+    }
+
+    @Test
+    public void musicFoldersListExample() throws Exception {
+
+        FieldDescriptor[] musicFolder = new FieldDescriptor[] {
+                fieldWithPath("id").description("Music Folder id"),
+                fieldWithPath("path").description("Filesystem path"),
+                fieldWithPath("name").description("Short name for folder"),
+                fieldWithPath("enabled").description("Is the folder enabled"),
+                fieldWithPath("changed").description("When the corresponding database entry was last changed")
+        };
+
+        this.mockMvc.perform(
+                get("/api/musicFolders")
+                        .accept(APPLICATION_JSON)
+                )
+                .andExpect(status().is(200))
+                .andDo(documentationHandler.document(
+                        // TODO maybe do this in the future
+//                        requestParameters(
+//                                parameterWithName("includeNonExisting")
+//                                        .description("Include folders that are not present. Defaults to false")
+//                                        .optional(),
+//                                parameterWithName("includeDisabled")
+//                                        .description("Include folders that are disabled. Defaults to false")
+//                                        .optional()),
+                        responseFields(fieldWithPath("[]").description("Array of music folders. " +
+                                "Does not include folders that are disabled or not present on the filesystem"))
+                                .andWithPrefix("[].", musicFolder)
+                ));
+    }
+
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/api/RESTControllerTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/api/RESTControllerTestCase.java
@@ -1,0 +1,73 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2016 (C) Airsonic Authors
+ Based upon Subsonic, Copyright 2009 (C) Sindre Mehus
+ */
+package org.airsonic.player.controller.api;
+
+import org.junit.Test;
+
+import javax.servlet.RequestDispatcher;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class RESTControllerTestCase extends BaseRESTControllerTestCase {
+
+    // This test is a bit of a hack for
+    // https://github.com/spring-projects/spring-boot/issues/5574
+    @Test
+    public void errorExample() throws Exception {
+
+
+        this.mockMvc.perform(
+                get("/error")
+                        .accept(APPLICATION_JSON)
+                        .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 400)
+                        .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/api/nonexistant")
+                        .requestAttr(RequestDispatcher.ERROR_MESSAGE, "No message available"))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("error", is("Bad Request")))
+                .andExpect(jsonPath("status", is(400)))
+                .andExpect(jsonPath("message", is("No message available")))
+                .andExpect(jsonPath("timestamp", isA(Long.class)))
+                .andExpect(jsonPath("path", is("/api/nonexistant")))
+                .andDo(documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("error").description("The HTTP error that occurred, e.g. `Bad Request`"),
+                                fieldWithPath("message").description("A description of the cause of the error"),
+                                fieldWithPath("path").description("The path to which the request was made"),
+                                fieldWithPath("status").description("The HTTP status code, e.g. `400`"),
+                                fieldWithPath("timestamp").description("The time, in milliseconds, at which the error occurred"))
+                        ));
+    }
+
+    // TODO 204 seems to generate a "null" body with 4 bytes. Should be 0 bytes...
+    @Test
+    public void indexExample() throws Exception {
+        this.mockMvc.perform(get("/api/").accept(APPLICATION_JSON))
+                .andExpect(status().is(204))
+                .andDo(documentationHandler.document());
+    }
+
+}


### PR DESCRIPTION
Hopefully this is a more review-able chunk of code than #537. The idea here is to implement all of the endpoints one by one and document them using spring rest docs rather than copy over the existing subsonic api directly.

Biggest thing I still need to do is figure out a good security method. I don't think we want to use the existing subsonic rest security scheme.

cc @bfkelsey @yoyo007 