### PR TITLE
Stop airsonic from creating double slashes in urls.

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/NowPlayingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/NowPlayingService.java
@@ -113,20 +113,20 @@ public class NowPlayingService {
 
             String artist = mediaFile.getArtist();
             String title = mediaFile.getTitle();
-            String streamUrl = url + "/stream?player=" + player.getId() + "&id=" + mediaFile.getId();
-            String albumUrl = url + "/main.view?id=" + mediaFile.getId();
+            String streamUrl = url + "stream?player=" + player.getId() + "&id=" + mediaFile.getId();
+            String albumUrl = url + "main.view?id=" + mediaFile.getId();
             String lyricsUrl = null;
             if (!mediaFile.isVideo()) {
-                lyricsUrl = url + "/lyrics.view?artistUtf8Hex=" + StringUtil.utf8HexEncode(artist) +
+                lyricsUrl = url + "lyrics.view?artistUtf8Hex=" + StringUtil.utf8HexEncode(artist) +
                                                         "&songUtf8Hex=" + StringUtil.utf8HexEncode(title);
             }
-            String coverArtUrl = url + "/coverArt.view?size=60&id=" + mediaFile.getId();
+            String coverArtUrl = url + "coverArt.view?size=60&id=" + mediaFile.getId();
 
             String avatarUrl = null;
             if (userSettings.getAvatarScheme() == AvatarScheme.SYSTEM) {
-                avatarUrl = url + "/avatar.view?id=" + userSettings.getSystemAvatarId();
+                avatarUrl = url + "avatar.view?id=" + userSettings.getSystemAvatarId();
             } else if (userSettings.getAvatarScheme() == AvatarScheme.CUSTOM && settingsService.getCustomAvatar(username) != null) {
-                avatarUrl = url + "/avatar.view?usernameUtf8Hex=" + StringUtil.utf8HexEncode(username);
+                avatarUrl = url + "avatar.view?usernameUtf8Hex=" + StringUtil.utf8HexEncode(username);
             }
 
             String tooltip = StringUtil.toHtml(artist) + " &ndash; " + StringUtil.toHtml(title);

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueService.java
@@ -647,7 +647,7 @@ public class PlayQueueService {
     private PlayQueueInfo convert(HttpServletRequest request, Player player, boolean serverSidePlaylist, int offset) throws Exception {
         String url = NetworkService.getBaseUrl(request);
 
-       /* if (serverSidePlaylist && player.isJukebox()) {
+        /* if (serverSidePlaylist && player.isJukebox()) {
             updateJukebox(player, offset);
         } */
         boolean isCurrentPlayer = player.getIpAddress() != null && player.getIpAddress().equals(request.getRemoteAddr());
@@ -661,12 +661,12 @@ public class PlayQueueService {
 
         for (MediaFile file : playQueue.getFiles()) {
 
-            String albumUrl = url + "/main.view?id=" + file.getId();
-            String streamUrl = url + "/stream?player=" + player.getId() + "&id=" + file.getId();
-            String coverArtUrl = url + "/coverArt.view?id=" + file.getId();
+            String albumUrl = url + "main.view?id=" + file.getId();
+            String streamUrl = url + "stream?player=" + player.getId() + "&id=" + file.getId();
+            String coverArtUrl = url + "coverArt.view?id=" + file.getId();
 
-            String remoteStreamUrl = jwtSecurityService.addJWTToken(url + "/ext/stream?player=" + player.getId() + "&id=" + file.getId());
-            String remoteCoverArtUrl = jwtSecurityService.addJWTToken(url + "/ext/coverArt.view?id=" + file.getId());
+            String remoteStreamUrl = jwtSecurityService.addJWTToken(url + "ext/stream?player=" + player.getId() + "&id=" + file.getId());
+            String remoteCoverArtUrl = jwtSecurityService.addJWTToken(url + "ext/coverArt.view?id=" + file.getId());
 
             String format = formatFormat(player, file);
             String username = securityService.getCurrentUsername(request);

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/ExternalPlayerController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/ExternalPlayerController.java
@@ -128,7 +128,7 @@ public class ExternalPlayerController {
     }
 
     public MediaFileWithUrlInfo addUrlInfo(HttpServletRequest request, Player player, MediaFile mediaFile, Date expires) {
-        String prefix = "/ext";
+        String prefix = "ext";
         String streamUrl = jwtSecurityService.addJWTToken(
                 UriComponentsBuilder
                         .fromHttpUrl(NetworkService.getBaseUrl(request) + prefix + "/stream")

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/VideoPlayerController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/VideoPlayerController.java
@@ -71,8 +71,8 @@ public class VideoPlayerController {
         Integer duration = file.getDurationSeconds();
         String playerId = playerService.getPlayer(request, response).getId();
         String url = NetworkService.getBaseUrl(request);
-        String streamUrl = url + "/stream?id=" + file.getId() + "&player=" + playerId + "&format=mp4";
-        String coverArtUrl = url + "/coverArt.view?id=" + file.getId();
+        String streamUrl = url + "stream?id=" + file.getId() + "&player=" + playerId + "&format=mp4";
+        String coverArtUrl = url + "coverArt.view?id=" + file.getId();
 
         map.put("video", file);
         map.put("streamUrl", streamUrl);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/ShareService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/ShareService.java
@@ -125,7 +125,7 @@ public class ShareService {
     }
 
     public String getShareUrl(HttpServletRequest request, Share share) {
-        String shareUrl = NetworkService.getBaseUrl(request) + "/ext/share/" + share.getName();
+        String shareUrl = NetworkService.getBaseUrl(request) + "ext/share/" + share.getName();
         return jwtSecurityService.addJWTToken(UriComponentsBuilder.fromUriString(shareUrl), share.getExpires()).build().toUriString();
     }
 


### PR DESCRIPTION
NetworkService.getBaseUrl already appends a slash "/" to the end of the url before returning. A number of places in the code that use getBaseUrl were also adding a slash before the rest of the url. This was causing a number of urls to appear with double slashes e.g. "http://airsonic//stream?player=5&id=43282".

While these are technically valid urls and did not cause an issue when accessing Airsonic direclty or through Nginx, they did cause playback issues when using Traefik as a reverse proxy.

BTC: 1BBpMuaq7pcj9eH4vk9tRqwJUhJ9npTW2H
ETH: 0x5800d6ddfB56dF3900584584143389CBF955837d