### PR TITLE
FIX #574 : new jukebox: high-definition music playing at lower quality.

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.github.biconou</groupId>
             <artifactId>AudioPlayer</artifactId>
-            <version>0.2.3</version>
+            <version>0.2.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This fix brings better respect of original high quality audio while playing in new jukebox mode. 
Known issue is that volume control is sometimes unavailable with high definition audio streams.