### PR TITLE
Dep Check Plugin and update vuln dependencies

### DIFF
--- a/airsonic-main/cve-suppressed.xml
+++ b/airsonic-main/cve-suppressed.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+    <suppress>
+        <notes><![CDATA[RC4 vulnerability in ssl. We don't use ssl at the application container level]]></notes>
+        <gav regex="true">^.*$</gav>
+        <cve>CVE-2015-2808</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[RC4 vulnerability in ssl. We don't use ssl at the application container level]]></notes>
+        <gav regex="true">^.*$</gav>
+        <cve>CVE-2013-2566</cve>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[This is for ruby - not for java and besides we don't allow user supplied information in emails]]></notes>
+        <gav regex="true">^.*$</gav>
+        <cve>CVE-2015-9097</cve>
+    </suppress>
+
+    <!-- This is for the oracle/glassfish application server implementation, not the api. -->
+    <suppress>
+        <notes><![CDATA[file name: javax.servlet.jsp-api-2.3.1.jar]]></notes>
+        <gav regex="true">^javax\.servlet\.jsp:javax\.servlet\.jsp-api:.*$</gav>
+        <cve>CVE-2011-5035</cve>
+    </suppress>
+
+    <!-- For drupal, so doesn't apply to us -->
+    <suppress>
+        <notes><![CDATA[file name: validation-api-1.1.0.Final.jar]]></notes>
+        <gav regex="true">^javax\.validation:validation-api:.*$</gav>
+        <cve>CVE-2013-4499</cve>
+    </suppress>
+
+    <!-- This seems to pick up many false positives for the server component which we have no control over -->
+    <suppress>
+        <notes><![CDATA[file name: mysql-connector-java-5.1.43.jar]]></notes>
+        <gav regex="true">^mysql:mysql-connector-java:.*$</gav>
+        <cpe regex="true">.*</cpe>
+    </suppress>
+
+    <!-- Jetty is currently only used for developer experimentation -->
+    <suppress>
+        <notes><![CDATA[file name: jetty-schemas-3.1.jar]]></notes>
+        <gav regex="true">^org\.eclipse\.jetty\.toolchain:jetty-schemas:.*$</gav>
+        <cve>CVE-2017-9735</cve>
+    </suppress>
+
+    <!-- No git functionality is used from the following dependencies -->
+    <suppress>
+        <notes><![CDATA[file name: org.eclipse.persistence.core-2.5.1.jar]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:org\.eclipse\.persistence\..*$</gav>
+        <cve>CVE-2017-14867</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: org.eclipse.persistence.core-2.5.1.jar]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:org\.eclipse\.persistence\..*$</gav>
+        <cve>CVE-2015-7545</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: org.eclipse.persistence.core-2.5.1.jar]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:org\.eclipse\.persistence\..*$</gav>
+        <cve>CVE-2015-7082</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: org.eclipse.persistence.core-2.5.1.jar]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:org\.eclipse\.persistence\..*$</gav>
+        <cve>CVE-2010-2542</cve>
+    </suppress>
+
+    <!-- Ignore all false positives for the server component -->
+    <suppress>
+        <notes><![CDATA[file name: mariadb-java-client-2.1.0.jar]]></notes>
+        <gav regex="true">^org\.mariadb\.jdbc:mariadb-java-client:.*$</gav>
+        <cpe>cpe:/a:mariadb:mariadb</cpe>
+    </suppress>
+
+    <!-- This cve is not for spring ldap, but for typo3 -->
+    <suppress>
+        <notes><![CDATA[file name: spring-ldap-core-2.3.1.RELEASE.jar]]></notes>
+        <gav regex="true">^org\.springframework\.ldap:spring-ldap-core:.*$</gav>
+        <cve>CVE-2014-6232</cve>
+    </suppress>
+
+    <!-- We do not support https for the embedded tomcat setup -->
+    <suppress>
+        <notes><![CDATA[file name: tomcat-annotations-api-8.5.23.jar]]></notes>
+        <gav regex="true">^org\.apache\.tomcat:tomcat-annotations-api:.*$</gav>
+        <cve>CVE-2017-6056</cve>
+    </suppress>
+
+    <!-- This only impacts distro packages, not embedded -->
+    <suppress>
+        <notes><![CDATA[file name: tomcat-annotations-api-8.5.23.jar]]></notes>
+        <gav regex="true">^org\.apache\.tomcat:tomcat-annotations-api:.*$</gav>
+        <cve>CVE-2016-6325</cve>
+    </suppress>
+
+    <!-- This only impacts distro packages, not embedded -->
+    <suppress>
+        <notes><![CDATA[file name: tomcat-annotations-api-8.5.23.jar]]></notes>
+        <gav regex="true">^org\.apache\.tomcat:tomcat-annotations-api:.*$</gav>
+        <cve>CVE-2016-5425</cve>
+    </suppress>
+
+    <!-- Jetty is currently disabled and not added to the built war -->
+    <suppress>
+        <notes><![CDATA[file name: jetty-schemas-3.1.jar]]></notes>
+        <gav regex="true">^org\.eclipse\.jetty\..*$</gav>
+        <cpe>cpe:/a:mortbay_jetty:jetty</cpe>
+    </suppress>
+</suppressions>

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <metrics.version>3.1.0</metrics.version>
-        <chameleon.version>1.2.0-RELEASE</chameleon.version>
+        <chameleon.version>1.2.1-RELEASE</chameleon.version>
     </properties>
 
     <dependencies>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.2</version>
+            <version>1.3.3</version>
         </dependency>
 
         <dependency>
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.1</version>
+            <version>2.6</version>
         </dependency>
 
         <dependency>
@@ -264,6 +264,12 @@
             <artifactId>jstl</artifactId>
             <version>1.2</version>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>stax</groupId>
+            <artifactId>stax-api</artifactId>
+            <version>1.0.1</version>
         </dependency>
 
         <dependency>
@@ -491,7 +497,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.2</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>
@@ -568,7 +574,10 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>1.5.6.RELEASE</version>
+                <version>1.5.8.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -107,6 +107,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.3.2</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.5</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -187,11 +192,29 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>3.0.1</version>
+                    <inherited>true</inherited>
+                    <configuration>
+                        <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+                        <suppressionFile>${project.basedir}/cve-suppressed.xml</suppressionFile>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>run-dependency-checker</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -223,6 +246,7 @@
                                 <ignoredUsedUndeclaredDependency>org.springframework.security:*</ignoredUsedUndeclaredDependency>
                                 <ignoredUsedUndeclaredDependency>org.springframework.boot:*</ignoredUsedUndeclaredDependency>
                                 <ignoredUsedUndeclaredDependency>org.apache.tomcat.embed:tomcat-embed-core*</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.apache.tomcat:tomcat-annotations-api:*</ignoredUsedUndeclaredDependency>
                             </ignoredUsedUndeclaredDependencies>
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>com.sun.mail:javax.mail*</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
Add a dependency check plugin to find reported issues with dependencies
we use.

From adding this, there were quite a few false positives which are
documented in airsonic-main/cve-suppressed.xml. The applicable
vulnerabilities are as follows:

```
commons-fileupload-1.2.jar (commons-fileupload:commons-fileupload:1.2,
cpe:/a:apache:commons_fileupload:1.2) : CVE-2016-3092, CVE-2016-1000031,
CVE-2014-0050, CVE-2013-0248
castor-core-1.3.1.jar (cpe:/a:castor:castor:1.3.1,
cpe:/a:castor_project:castor:1.3.1,
org.codehaus.castor:castor-core:1.3.1) : CVE-2014-3004
```

CVE-2016-1000031 is rated as CRITICAL, but we do not deserialize content
from any multipart uploads so doesn't apply.

Signed-off-by: Andrew DeMaria <lostonamountain@gmail.com>