### PR TITLE
Don't require csrf for search endpoint

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
@@ -125,7 +125,6 @@
 
         <td style="padding-left:1em">
             <form method="post" action="search.view" target="main" name="searchForm">
-                <sec:csrfInput />
                 <td><input type="text" name="query" id="query" size="28" placeholder="${search}" onclick="select();"
                            onkeyup="triggerInstantSearch();"></td>
                 <td><a href="javascript:document.searchForm.submit()"><img src="<spring:theme code="searchImage"/>" alt="${search}" title="${search}"></a></td>


### PR DESCRIPTION
Reasoning:

- It doesn't change state and is not a sensitive endpoint
- It really should be changed to GET but that is a bit more intrusive
  change that can be done at another time
- The search csrf token is stored on the top.jsp page for a long time.
  If the user keeps this tab open for a while it is possible the csrf
  token will change on their session with other requests going on such
  that the search csrf token becomes wrong/stale.

Fixes #517 and #536. Supersedes #552  

Signed-off-by: Andrew DeMaria <lostonamountain@gmail.com>