### PR TITLE
Fix NPE at java FontConfiguration when running in docker container.

### DIFF
--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -12,6 +12,8 @@ RUN apk --no-cache add \
     lame \
     bash \
     libressl \
+    fontconfig \
+    ttf-dejavu \
     ca-certificates \
     tini \
     openjdk8-jre


### PR DESCRIPTION
Base image Alpine-JRE8 doesn't install as dependency fontconfig and
some font. Added them to buildsteps.

Signed-off-by: Yahor Berdnikau <egorr.berd@gmail.com>

Checked by build docker image with applied patch from v10.1.0 tag - haven't observed any NPE in logs.
Fixes #627 