### PR TITLE
Upgrade jaudiotagger to 2.2.5 supporting Java 9

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -215,7 +215,7 @@
         <dependency>
             <groupId>net.jthink</groupId>
             <artifactId>jaudiotagger</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
jaudiotagger version 2.2.3 is using sun.nio.ch.DirectBuffer which has been removed in Java 9.
Upstream jaudiotagger 2.2.5 fixes this.

I tested and confirm writing of mp3 tags under Java 9 is working with 2.2.5.

As discussed here: https://github.com/airsonic/airsonic/issues/611


