### PR TITLE
Issue 617 - fixes DLNA RecentAlbum browsing 

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
@@ -26,10 +26,8 @@ import org.airsonic.player.domain.CoverArtScheme;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.service.SearchService;
-import org.fourthline.cling.support.model.BrowseResult;
 import org.fourthline.cling.support.model.DIDLContent;
 import org.fourthline.cling.support.model.PersonWithRole;
-import org.fourthline.cling.support.model.SortCriterion;
 import org.fourthline.cling.support.model.container.Container;
 import org.fourthline.cling.support.model.container.MusicAlbum;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,20 +59,6 @@ public class AlbumUpnpProcessor extends UpnpContentProcessor <Album, MediaFile> 
         setRootTitle("Albums");
     }
 
-    /**
-     * Browses the top-level content of a type.
-     */
-    public BrowseResult browseRoot(String filter, long firstResult, long maxResults, SortCriterion[] orderBy) throws Exception {
-        DIDLContent didl = new DIDLContent();
-
-        List<MusicFolder> allFolders = getDispatchingContentDirectory().getSettingsService().getAllMusicFolders();
-        List<Album> selectedItems = getAlbumDao().getAlphabeticalAlbums((int) firstResult, (int) maxResults, false, true, allFolders);
-        for (Album item : selectedItems) {
-            addItem(didl, item);
-        }
-
-        return createBrowseResult(didl, (int) didl.getCount(), getAllItemsSize());
-    }
     public Container createContainer(Album album) throws Exception {
         MusicAlbum container = new MusicAlbum();
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
@@ -26,8 +26,10 @@ import org.airsonic.player.domain.CoverArtScheme;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.service.SearchService;
+import org.fourthline.cling.support.model.BrowseResult;
 import org.fourthline.cling.support.model.DIDLContent;
 import org.fourthline.cling.support.model.PersonWithRole;
+import org.fourthline.cling.support.model.SortCriterion;
 import org.fourthline.cling.support.model.container.Container;
 import org.fourthline.cling.support.model.container.MusicAlbum;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,6 +61,20 @@ public class AlbumUpnpProcessor extends UpnpContentProcessor <Album, MediaFile> 
         setRootTitle("Albums");
     }
 
+    /**
+     * Browses the top-level content of a type.
+     */
+    public BrowseResult browseRoot(String filter, long firstResult, long maxResults, SortCriterion[] orderBy) throws Exception {
+        DIDLContent didl = new DIDLContent();
+
+        List<MusicFolder> allFolders = getDispatchingContentDirectory().getSettingsService().getAllMusicFolders();
+        List<Album> selectedItems = getAlbumDao().getAlphabeticalAlbums((int) firstResult, (int) maxResults, false, true, allFolders);
+        for (Album item : selectedItems) {
+            addItem(didl, item);
+        }
+
+        return createBrowseResult(didl, (int) didl.getCount(), getAllItemsSize());
+    }
     public Container createContainer(Album album) throws Exception {
         MusicAlbum container = new MusicAlbum();
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/RecentAlbumUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/RecentAlbumUpnpProcessor.java
@@ -37,6 +37,7 @@ public class RecentAlbumUpnpProcessor extends AlbumUpnpProcessor {
         setRootTitle("RecentAlbums");
     }
 
+    @Override
     public List<Album> getAllItems() {
         List<MusicFolder> allFolders = getDispatchingContentDirectory().getSettingsService().getAllMusicFolders();
         List<Album> recentAlbums = getAlbumDao().getNewestAlbums(0, RECENT_COUNT, allFolders);
@@ -50,5 +51,12 @@ public class RecentAlbumUpnpProcessor extends AlbumUpnpProcessor {
             recentAlbums.add(0, viewAll);
         }
         return recentAlbums;
+    }
+
+    @Override
+    public int getAllItemsSize() throws Exception {
+        List<MusicFolder> allFolders = getDispatchingContentDirectory().getSettingsService().getAllMusicFolders();
+        int allAlbumCount = getAlbumDao().getAlbumCount(allFolders);
+        return Math.min(allAlbumCount, RECENT_COUNT);
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/RecentAlbumUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/RecentAlbumUpnpProcessor.java
@@ -20,6 +20,10 @@
 package org.airsonic.player.service.upnp;
 import org.airsonic.player.domain.Album;
 import org.airsonic.player.domain.MusicFolder;
+import org.airsonic.player.util.Util;
+import org.fourthline.cling.support.model.BrowseResult;
+import org.fourthline.cling.support.model.DIDLContent;
+import org.fourthline.cling.support.model.SortCriterion;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -35,6 +39,28 @@ public class RecentAlbumUpnpProcessor extends AlbumUpnpProcessor {
     public RecentAlbumUpnpProcessor() {
         setRootId(DispatchingContentDirectory.CONTAINER_ID_RECENT_PREFIX);
         setRootTitle("RecentAlbums");
+    }
+
+    /**
+     * Browses the top-level content.
+     */
+    public BrowseResult browseRoot(String filter, long firstResult, long maxResults, SortCriterion[] orderBy) throws Exception {
+        // AlbumUpnpProcessor overrides browseRoot() with an optimization;
+        // this restores the default behavior for the subclass.
+        DIDLContent didl = new DIDLContent();
+        List<Album> allItems = getAllItems();
+        if (filter != null) {
+            // filter items (not implemented yet)
+        }
+        if (orderBy != null) {
+            // sort items (not implemented yet)
+        }
+        List<Album> selectedItems = Util.subList(allItems, firstResult, maxResults);
+        for (Album item : selectedItems) {
+            addItem(didl, item);
+        }
+
+        return createBrowseResult(didl, (int) didl.getCount(), allItems.size());
     }
 
     @Override


### PR DESCRIPTION
Removes an incorrect override in AlbumUpnpProcessor which was preventing
RecentAlbumUpnpProcessor from behaving correctly.

Also adds a correct getAllItemsSize() implementation for RecentAlbumUpnpProcessor.
