### PR TITLE
Catch ClientAbortException exception to avoid huge traceback fix #724

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -29,6 +29,7 @@ import org.airsonic.player.service.sonos.SonosHelper;
 import org.airsonic.player.util.HttpRange;
 import org.airsonic.player.util.StringUtil;
 import org.airsonic.player.util.Util;
+import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -248,7 +249,9 @@ public class StreamController  {
                     }
                 }
             }
-
+        } catch (ClientAbortException err) {
+            LOG.info("org.apache.catalina.connector.ClientAbortException: Connection reset");
+            return;
         } finally {
             if (status != null) {
                 securityService.updateUserByteCounts(user, status.getBytesTransfered(), 0L, 0L);


### PR DESCRIPTION
A one line log replace the full backtrace