### PR TITLE
Handle player id as an Integer instead of String

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/NowPlayingInfo.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/NowPlayingInfo.java
@@ -26,7 +26,7 @@ package org.airsonic.player.ajax;
  */
 public class NowPlayingInfo {
 
-    private final String playerId;
+    private final Integer playerId;
     private final String username;
     private final String artist;
     private final String title;
@@ -38,7 +38,7 @@ public class NowPlayingInfo {
     private final String avatarUrl;
     private final int minutesAgo;
 
-    public NowPlayingInfo(String playerId, String user, String artist, String title, String tooltip, String streamUrl, String albumUrl,
+    public NowPlayingInfo(Integer playerId, String user, String artist, String title, String tooltip, String streamUrl, String albumUrl,
                           String lyricsUrl, String coverArtUrl, String avatarUrl, int minutesAgo) {
         this.playerId = playerId;
         this.username = user;
@@ -53,7 +53,7 @@ public class NowPlayingInfo {
         this.minutesAgo = minutesAgo;
     }
 
-    public String getPlayerId() {
+    public Integer getPlayerId() {
         return playerId;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueService.java
@@ -149,7 +149,7 @@ public class PlayQueueService {
         return convert(request, player, false);
     }
 
-    public void savePlayQueue(int currentSongIndex, long positionMillis) {
+    public void savePlayQueue(int currentSongIndex, long positionMillis) throws Exception {
         HttpServletRequest request = WebContextFactory.get().getHttpServletRequest();
         HttpServletResponse response = WebContextFactory.get().getHttpServletResponse();
 
@@ -710,11 +710,11 @@ public class PlayQueueService {
         return mediaFile.getBitRate() + " Kbps";
     }
 
-    private Player getCurrentPlayer(HttpServletRequest request, HttpServletResponse response) {
+    private Player getCurrentPlayer(HttpServletRequest request, HttpServletResponse response) throws Exception {
         return playerService.getPlayer(request, response);
     }
 
-    private Player resolvePlayer() {
+    private Player resolvePlayer() throws Exception {
         return getCurrentPlayer(resolveHttpServletRequest(), resolveHttpServletResponse());
     }
 
@@ -732,7 +732,7 @@ public class PlayQueueService {
     // Methods dedicated to jukebox
     //
 
-    public void setGain(float gain) {
+    public void setGain(float gain) throws Exception {
         HttpServletRequest request = WebContextFactory.get().getHttpServletRequest();
         HttpServletResponse response = WebContextFactory.get().getHttpServletResponse();
         Player player = getCurrentPlayer(request, response);
@@ -741,7 +741,7 @@ public class PlayQueueService {
         }
     }
 
-    public void setJukeboxPosition(int positionInSeconds) {
+    public void setJukeboxPosition(int positionInSeconds) throws Exception {
         Player player = resolvePlayer();
         jukeboxService.setPosition(player,positionInSeconds);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/PlaylistService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/PlaylistService.java
@@ -112,7 +112,7 @@ public class PlaylistService {
         return getReadablePlaylists();
     }
 
-    public int createPlaylistForPlayQueue() {
+    public int createPlaylistForPlayQueue() throws Exception {
         HttpServletRequest request = WebContextFactory.get().getHttpServletRequest();
         HttpServletResponse response = WebContextFactory.get().getHttpServletResponse();
         Player player = playerService.getPlayer(request, response);
@@ -167,7 +167,7 @@ public class PlaylistService {
         }
         playlistService.setFilesInPlaylist(playlistId, files);
     }
-    
+
     private List<PlaylistInfo.Entry> createEntries(List<MediaFile> files) {
         List<PlaylistInfo.Entry> result = new ArrayList<PlaylistInfo.Entry>();
         for (MediaFile file : files) {

--- a/airsonic-main/src/main/java/org/airsonic/player/command/PlayerSettingsCommand.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/command/PlayerSettingsCommand.java
@@ -34,7 +34,7 @@ import java.util.List;
  * @author Sindre Mehus
  */
 public class PlayerSettingsCommand {
-    private String playerId;
+    private Integer playerId;
     private String name;
     private String description;
     private String type;
@@ -55,11 +55,11 @@ public class PlayerSettingsCommand {
     private String javaJukeboxMixer;
     private String[] javaJukeboxMixers;
 
-    public String getPlayerId() {
+    public Integer getPlayerId() {
         return playerId;
     }
 
-    public void setPlayerId(String playerId) {
+    public void setPlayerId(Integer playerId) {
         this.playerId = playerId;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -99,7 +99,7 @@ public class DownloadController implements LastModified {
             MediaFile mediaFile = getMediaFile(request);
 
             Integer playlistId = ServletRequestUtils.getIntParameter(request, "playlist");
-            String playerId = request.getParameter("player");
+            Integer playerId = ServletRequestUtils.getIntParameter(request, "player");
             int[] indexes = request.getParameter("i") == null ? null : ServletRequestUtils.getIntParameters(request, "i");
 
             if (mediaFile != null) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/LeftController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/LeftController.java
@@ -68,7 +68,7 @@ public class LeftController  {
      * Note: This class intentionally does not implement org.springframework.web.servlet.mvc.LastModified
      * as we don't need browser-side caching of left.jsp.  This method is only used by RESTController.
      */
-    long getLastModified(HttpServletRequest request) {
+    long getLastModified(HttpServletRequest request) throws Exception {
         saveSelectedMusicFolder(request);
 
         if (mediaScannerService.isScanning()) {
@@ -157,12 +157,11 @@ public class LeftController  {
         return new ModelAndView("left","model",map);
     }
 
-    private boolean saveSelectedMusicFolder(HttpServletRequest request) {
-        if (request.getParameter("musicFolderId") == null) {
+    private boolean saveSelectedMusicFolder(HttpServletRequest request) throws Exception {
+        Integer musicFolderId = ServletRequestUtils.getIntParameter(request, "musicFolderId");
+        if (musicFolderId == null) {
             return false;
         }
-        int musicFolderId = Integer.parseInt(request.getParameter("musicFolderId"));
-
         // Note: UserSettings.setChanged() is intentionally not called. This would break browser caching
         // of the left frame.
         UserSettings settings = settingsService.getUserSettings(securityService.getCurrentUsername(request));

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/ShareManagementController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/ShareManagementController.java
@@ -94,7 +94,7 @@ public class ShareManagementController  {
 
     private List<MediaFile> getMediaFiles(HttpServletRequest request) throws Exception {
         Integer id = ServletRequestUtils.getIntParameter(request, "id");
-        String playerId = request.getParameter("player");
+        Integer playerId = ServletRequestUtils.getIntParameter(request, "player");
         Integer playlistId = ServletRequestUtils.getIntParameter(request, "playlist");
 
         List<MediaFile> result = new ArrayList<>();

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StatusChartController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StatusChartController.java
@@ -32,6 +32,7 @@ import org.jfree.data.Range;
 import org.jfree.data.time.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
@@ -62,7 +63,7 @@ public class StatusChartController extends AbstractChartController {
     @RequestMapping(method = RequestMethod.GET)
     public synchronized ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
         String type = request.getParameter("type");
-        int index = Integer.parseInt(request.getParameter("index"));
+        int index = ServletRequestUtils.getIntParameter(request, "index");
 
         List<TransferStatus> statuses = Collections.emptyList();
         if ("stream".equals(type)) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -1225,7 +1225,7 @@ public class SubsonicRESTController {
             if (minutesAgo < 60) {
                 NowPlayingEntry entry = new NowPlayingEntry();
                 entry.setUsername(username);
-                entry.setPlayerId(Integer.parseInt(player.getId()));
+                entry.setPlayerId(player.getId());
                 entry.setPlayerName(player.getName());
                 entry.setMinutesAgo((int) minutesAgo);
                 result.getEntry().add(createJaxbChild(entry, player, mediaFile, username));
@@ -2399,7 +2399,7 @@ public class SubsonicRESTController {
         }
 
         // Return the player ID.
-        return !players.isEmpty() ? players.get(0).getId() : null;
+        return !players.isEmpty() ? String.valueOf(players.get(0).getId()) : null;
     }
 
     private Locale getUserLocale(HttpServletRequest request) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/VideoPlayerController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/VideoPlayerController.java
@@ -69,7 +69,7 @@ public class VideoPlayerController {
         mediaFileService.populateStarredDate(file, user.getUsername());
 
         Integer duration = file.getDurationSeconds();
-        String playerId = playerService.getPlayer(request, response).getId();
+        Integer playerId = playerService.getPlayer(request, response).getId();
         String url = NetworkService.getBaseUrl(request);
         String streamUrl = url + "stream?id=" + file.getId() + "&player=" + playerId + "&format=mp4";
         String coverArtUrl = url + "coverArt.view?id=" + file.getId();

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PlayerDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PlayerDao.java
@@ -20,7 +20,6 @@
 package org.airsonic.player.dao;
 
 import org.airsonic.player.domain.*;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
@@ -45,7 +44,7 @@ public class PlayerDao extends AbstractDao {
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
     private PlayerRowMapper rowMapper = new PlayerRowMapper();
-    private Map<String, PlayQueue> playlists = Collections.synchronizedMap(new HashMap<String, PlayQueue>());
+    private Map<Integer, PlayQueue> playlists = Collections.synchronizedMap(new HashMap<Integer, PlayQueue>());
 
     /**
      * Returns all players.
@@ -81,13 +80,9 @@ public class PlayerDao extends AbstractDao {
      * @param id The unique player ID.
      * @return The player with the given ID, or <code>null</code> if no such player exists.
      */
-    public Player getPlayerById(String id) {
-        if (StringUtils.isBlank(id)) {
-            return null;
-        } else {
-            String sql = "select " + QUERY_COLUMNS + " from player where id=?";
-            return queryOne(sql, rowMapper, id);
-        }
+    public Player getPlayerById(int id) {
+        String sql = "select " + QUERY_COLUMNS + " from player where id=?";
+        return queryOne(sql, rowMapper, id);
     }
 
     /**
@@ -102,7 +97,7 @@ public class PlayerDao extends AbstractDao {
             existingMax = 0;
         }
         int id = existingMax + 1;
-        player.setId(String.valueOf(id));
+        player.setId(id);
         String sql = "insert into player (" + QUERY_COLUMNS + ") values (" + questionMarks(QUERY_COLUMNS) + ")";
         update(sql, player.getId(), player.getName(), player.getType(), player.getUsername(),
                player.getIpAddress(), player.isAutoControlEnabled(), player.isM3uBomEnabled(),
@@ -119,7 +114,7 @@ public class PlayerDao extends AbstractDao {
      *
      * @param id The player ID.
      */
-    public void deletePlayer(String id) {
+    public void deletePlayer(Integer id) {
         String sql = "delete from player where id=?";
         update(sql, id);
         playlists.remove(id);
@@ -181,7 +176,7 @@ public class PlayerDao extends AbstractDao {
         public Player mapRow(ResultSet rs, int rowNum) throws SQLException {
             Player player = new Player();
             int col = 1;
-            player.setId(rs.getString(col++));
+            player.setId(rs.getInt(col++));
             player.setName(rs.getString(col++));
             player.setType(rs.getString(col++));
             player.setUsername(rs.getString(col++));

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/TranscodingDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/TranscodingDao.java
@@ -59,7 +59,7 @@ public class TranscodingDao extends AbstractDao {
      * @param playerId The player ID.
      * @return All active transcodings for the player.
      */
-    public List<Transcoding> getTranscodingsForPlayer(String playerId) {
+    public List<Transcoding> getTranscodingsForPlayer(Integer playerId) {
         String sql = "select " + QUERY_COLUMNS + " from transcoding2, player_transcoding2 " +
                      "where player_transcoding2.player_id = ? " +
                      "and   player_transcoding2.transcoding_id = transcoding2.id";
@@ -72,7 +72,7 @@ public class TranscodingDao extends AbstractDao {
      * @param playerId       The player ID.
      * @param transcodingIds ID's of the active transcodings.
      */
-    public void setTranscodingsForPlayer(String playerId, int[] transcodingIds) {
+    public void setTranscodingsForPlayer(Integer playerId, int[] transcodingIds) {
         update("delete from player_transcoding2 where player_id = ?", playerId);
         String sql = "insert into player_transcoding2(player_id, transcoding_id) values (?, ?)";
         for (int transcodingId : transcodingIds) {

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Player.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Player.java
@@ -31,7 +31,7 @@ import java.util.Date;
  */
 public class Player {
 
-    private String id;
+    private Integer id;
     private String name;
     private PlayerTechnology technology = PlayerTechnology.WEB;
     private String clientId;
@@ -51,7 +51,7 @@ public class Player {
      *
      * @return The player ID.
      */
-    public String getId() {
+    public Integer getId() {
         return id;
     }
 
@@ -60,7 +60,7 @@ public class Player {
      *
      * @param id The player ID.
      */
-    public void setId(String id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Transcoding.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Transcoding.java
@@ -74,7 +74,7 @@ public class Transcoding {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxJavaService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxJavaService.java
@@ -39,7 +39,7 @@ public class JukeboxJavaService {
 
 
     private TransferStatus status;
-    private Map<String, com.github.biconou.AudioPlayer.api.Player> activeAudioPlayers = new Hashtable<>();
+    private Map<Integer, com.github.biconou.AudioPlayer.api.Player> activeAudioPlayers = new Hashtable<>();
     private Map<String, List<com.github.biconou.AudioPlayer.api.Player>> activeAudioPlayersPerMixer = new Hashtable<>();
     private final static String DEFAULT_MIXER_ENTRY_KEY = "_default";
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
@@ -49,7 +49,7 @@ public class StatusService {
     private final List<PlayStatus> remotePlays = new ArrayList<PlayStatus>();
 
     // Maps from player ID to latest inactive stream status.
-    private final Map<String, TransferStatus> inactiveStreamStatuses = new LinkedHashMap<String, TransferStatus>();
+    private final Map<Integer, TransferStatus> inactiveStreamStatuses = new LinkedHashMap<Integer, TransferStatus>();
 
     public synchronized TransferStatus createStreamStatus(Player player) {
         // Reuse existing status, if possible.
@@ -74,12 +74,12 @@ public class StatusService {
         List<TransferStatus> result = new ArrayList<TransferStatus>(streamStatuses);
 
         // Add inactive status for those players that have no active status.
-        Set<String> activePlayers = new HashSet<String>();
+        Set<Integer> activePlayers = new HashSet<Integer>();
         for (TransferStatus status : streamStatuses) {
             activePlayers.add(status.getPlayer().getId());
         }
 
-        for (Map.Entry<String, TransferStatus> entry : inactiveStreamStatuses.entrySet()) {
+        for (Map.Entry<Integer, TransferStatus> entry : inactiveStreamStatuses.entrySet()) {
             if (!activePlayers.contains(entry.getKey())) {
                 result.add(entry.getValue());
             }
@@ -142,7 +142,7 @@ public class StatusService {
     }
 
     public synchronized List<PlayStatus> getPlayStatuses() {
-        Map<String, PlayStatus> result = new LinkedHashMap<String, PlayStatus>();
+        Map<Integer, PlayStatus> result = new LinkedHashMap<Integer, PlayStatus>();
         for (PlayStatus remotePlay : remotePlays) {
             if (!remotePlay.isExpired()) {
                 result.put(remotePlay.getPlayer().getId(), remotePlay);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
@@ -118,9 +118,11 @@ public class TranscodingService {
         // Activate this transcoding for all players?
         if (transcoding.isDefaultActive()) {
             for (Player player : playerService.getAllPlayers()) {
-                List<Transcoding> transcodings = getTranscodingsForPlayer(player);
-                transcodings.add(transcoding);
-                setTranscodingsForPlayer(player, transcodings);
+                if (player != null) {
+                    List<Transcoding> transcodings = getTranscodingsForPlayer(player);
+                    transcodings.add(transcoding);
+                    setTranscodingsForPlayer(player, transcodings);
+                }
             }
         }
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/PlayerDaoTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/PlayerDaoTestCase.java
@@ -65,25 +65,25 @@ public class PlayerDaoTestCase extends DaoTestCaseBean2 {
         Player player = new Player();
 
         playerDao.createPlayer(player);
-        assertEquals("Wrong ID", "1", player.getId());
+        assertEquals("Wrong ID", (Integer)1, player.getId());
         assertEquals("Wrong number of players.", 1, playerDao.getAllPlayers().size());
 
         playerDao.createPlayer(player);
-        assertEquals("Wrong ID", "2", player.getId());
+        assertEquals("Wrong ID", (Integer)2, player.getId());
         assertEquals("Wrong number of players.", 2, playerDao.getAllPlayers().size());
 
         playerDao.createPlayer(player);
-        assertEquals("Wrong ID", "3", player.getId());
+        assertEquals("Wrong ID", (Integer)3, player.getId());
         assertEquals("Wrong number of players.", 3, playerDao.getAllPlayers().size());
 
-        playerDao.deletePlayer("3");
+        playerDao.deletePlayer(3);
         playerDao.createPlayer(player);
-        assertEquals("Wrong ID", "3", player.getId());
+        assertEquals("Wrong ID", (Integer)3, player.getId());
         assertEquals("Wrong number of players.", 3, playerDao.getAllPlayers().size());
 
-        playerDao.deletePlayer("2");
+        playerDao.deletePlayer(2);
         playerDao.createPlayer(player);
-        assertEquals("Wrong ID", "4", player.getId());
+        assertEquals("Wrong ID", (Integer)4, player.getId());
         assertEquals("Wrong number of players.", 3, playerDao.getAllPlayers().size());
     }
 
@@ -153,10 +153,10 @@ public class PlayerDaoTestCase extends DaoTestCaseBean2 {
         playerDao.createPlayer(new Player());
         assertEquals("Wrong number of players.", 2, playerDao.getAllPlayers().size());
 
-        playerDao.deletePlayer("1");
+        playerDao.deletePlayer(1);
         assertEquals("Wrong number of players.", 1, playerDao.getAllPlayers().size());
 
-        playerDao.deletePlayer("2");
+        playerDao.deletePlayer(2);
         assertEquals("Wrong number of players.", 0, playerDao.getAllPlayers().size());
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/StatusServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/StatusServiceTestCase.java
@@ -40,7 +40,7 @@ public class StatusServiceTestCase extends TestCase {
         super.setUp();
         service = new StatusService();
         player1 = new Player();
-        player1.setId("1");
+        player1.setId(1);
     }
 
     public void testSimpleAddRemove() {


### PR DESCRIPTION
Change player id to an Integer. This matches the internal type to the database, fixes type-casting issues when Postgres is used, and eliminates the need to have `stringtype=unspecified` on your JDBC connection URL.

Tested on:
MariaDB 10.2
Postgres 9.5
Default sqlite