### PR TITLE
Add option to disable seeking on transcodes. (Mitigates #548 & #723)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -309,7 +309,7 @@ public class CoverArtController implements LastModified {
         VideoTranscodingSettings videoSettings = new VideoTranscodingSettings(width, height, offset, 0, false);
         TranscodingService.Parameters parameters = new TranscodingService.Parameters(mediaFile, videoSettings);
         String command = settingsService.getVideoImageCommand();
-        parameters.setTranscoding(new Transcoding(null, null, null, null, command, null, null, false));
+        parameters.setTranscoding(new Transcoding(null, null, null, null, command, null, null, false, true));
         return transcodingService.getTranscodedInputStream(parameters);
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -152,19 +152,20 @@ public class StreamController  {
                 playQueue.addFiles(true, file);
                 player.setPlayQueue(playQueue);
 
-                if (!file.isVideo()) {
+                TranscodingService.Parameters parameters = transcodingService.getParameters(file, player, maxBitRate, preferredTargetFormat, null);
+
+                if (parameters.isEnableSeek() && !file.isVideo()) {
                     response.setIntHeader("ETag", file.getId());
                     response.setHeader("Accept-Ranges", "bytes");
                 }
 
-                TranscodingService.Parameters parameters = transcodingService.getParameters(file, player, maxBitRate, preferredTargetFormat, null);
                 long fileLength = getFileLength(parameters);
                 boolean isConversion = parameters.isDownsample() || parameters.isTranscode();
                 boolean estimateContentLength = ServletRequestUtils.getBooleanParameter(request, "estimateContentLength", false);
                 boolean isHls = ServletRequestUtils.getBooleanParameter(request, "hls", false);
 
                 range = getRange(request, file);
-                if (range != null && !file.isVideo()) {
+                if (parameters.isEnableSeek() && range != null && !file.isVideo()) {
                     LOG.info("Got HTTP range: " + range);
                     response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
                     Util.setContentLength(response, range.isClosed() ? range.size() : fileLength - range.getFirstBytePos());

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/TranscodingSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/TranscodingSettingsController.java
@@ -57,6 +57,7 @@ public class TranscodingSettingsController {
         map.put("transcodings", transcodingService.getAllTranscodings());
         map.put("transcodeDirectory", transcodingService.getTranscodeDirectory());
         map.put("downsampleCommand", settingsService.getDownsamplingCommand());
+        map.put("downsamplingEnableSeek", settingsService.isDownsamplingEnableSeek());
         map.put("hlsCommand", settingsService.getHlsCommand());
         map.put("brand", settingsService.getBrand());
 
@@ -84,6 +85,7 @@ public class TranscodingSettingsController {
             String step1 = getParameter(request, "step1", id);
             String step2 = getParameter(request, "step2", id);
             boolean delete = getParameter(request, "delete", id) != null;
+            boolean enableSeek = getParameter(request, "enableSeek", id) != null;
 
             if (delete) {
                 transcodingService.deleteTranscoding(id);
@@ -101,6 +103,7 @@ public class TranscodingSettingsController {
                 transcoding.setTargetFormat(targetFormat);
                 transcoding.setStep1(step1);
                 transcoding.setStep2(step2);
+                transcoding.setEnableSeek(enableSeek);
                 transcodingService.updateTranscoding(transcoding);
             }
         }
@@ -111,9 +114,10 @@ public class TranscodingSettingsController {
         String step1 = StringUtils.trimToNull(request.getParameter("step1"));
         String step2 = StringUtils.trimToNull(request.getParameter("step2"));
         boolean defaultActive = request.getParameter("defaultActive") != null;
+        boolean enableSeek = request.getParameter("enableSeek") != null;
 
         if (name != null || sourceFormats != null || targetFormat != null || step1 != null || step2 != null) {
-            Transcoding transcoding = new Transcoding(null, name, sourceFormats, targetFormat, step1, step2, null, defaultActive);
+            Transcoding transcoding = new Transcoding(null, name, sourceFormats, targetFormat, step1, step2, null, defaultActive, enableSeek);
             String error = null;
             if (name == null) {
                 error = "transcodingsettings.noname";
@@ -132,6 +136,7 @@ public class TranscodingSettingsController {
             }
         }
         settingsService.setDownsamplingCommand(StringUtils.trim(request.getParameter("downsampleCommand")));
+        settingsService.setDownsamplingEnableSeek(request.getParameter("downsampleEnableSeek") != null);
         settingsService.setHlsCommand(StringUtils.trim(request.getParameter("hlsCommand")));
         settingsService.save();
         return null;

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/TranscodingDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/TranscodingDao.java
@@ -39,7 +39,7 @@ import java.util.List;
 public class TranscodingDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(TranscodingDao.class);
-    private static final String INSERT_COLUMNS = "name, source_formats, target_format, step1, step2, step3, default_active";
+    private static final String INSERT_COLUMNS = "name, source_formats, target_format, step1, step2, step3, default_active, enable_seek";
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
     private TranscodingRowMapper rowMapper = new TranscodingRowMapper();
 
@@ -95,7 +95,8 @@ public class TranscodingDao extends AbstractDao {
         String sql = "insert into transcoding2 (" + QUERY_COLUMNS + ") values (" + questionMarks(QUERY_COLUMNS) + ")";
         update(sql, transcoding.getId(), transcoding.getName(), transcoding.getSourceFormats(),
                 transcoding.getTargetFormat(), transcoding.getStep1(),
-                transcoding.getStep2(), transcoding.getStep3(), transcoding.isDefaultActive());
+                transcoding.getStep2(), transcoding.getStep3(),
+                transcoding.isDefaultActive(), transcoding.isEnableSeek());
         LOG.info("Created transcoding " + transcoding.getName());
     }
 
@@ -117,16 +118,17 @@ public class TranscodingDao extends AbstractDao {
      */
     public void updateTranscoding(Transcoding transcoding) {
         String sql = "update transcoding2 set name=?, source_formats=?, target_format=?, " +
-                "step1=?, step2=?, step3=?, default_active=? where id=?";
+                "step1=?, step2=?, step3=?, default_active=?, enable_seek=? where id=?";
         update(sql, transcoding.getName(), transcoding.getSourceFormats(),
                 transcoding.getTargetFormat(), transcoding.getStep1(), transcoding.getStep2(),
-                transcoding.getStep3(), transcoding.isDefaultActive(), transcoding.getId());
+                transcoding.getStep3(), transcoding.isDefaultActive(),
+                transcoding.isEnableSeek(), transcoding.getId());
     }
 
     private static class TranscodingRowMapper implements RowMapper<Transcoding> {
         public Transcoding mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new Transcoding(rs.getInt(1), rs.getString(2), rs.getString(3), rs.getString(4), rs.getString(5),
-                    rs.getString(6), rs.getString(7), rs.getBoolean(8));
+                    rs.getString(6), rs.getString(7), rs.getBoolean(8), rs.getBoolean(9));
         }
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Transcoding.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Transcoding.java
@@ -40,6 +40,7 @@ public class Transcoding {
     private String step2;
     private String step3;
     private boolean defaultActive;
+    private boolean enableSeek;
 
     /**
      * Creates a new transcoding specification.
@@ -52,9 +53,10 @@ public class Transcoding {
      * @param step2           The command to execute in step 2.
      * @param step3           The command to execute in step 3.
      * @param defaultActive   Whether the transcoding should be automatically activated for all players.
+     * @param enableSeek      Whether seeking on streams should be enabled.
      */
     public Transcoding(Integer id, String name, String sourceFormats, String targetFormat, String step1,
-            String step2, String step3, boolean defaultActive) {
+            String step2, String step3, boolean defaultActive, boolean enableSeek) {
         this.id = id;
         this.name = name;
         this.sourceFormats = sourceFormats;
@@ -63,6 +65,7 @@ public class Transcoding {
         this.step2 = step2;
         this.step3 = step3;
         this.defaultActive = defaultActive;
+        this.enableSeek = enableSeek;
     }
 
     /**
@@ -188,6 +191,24 @@ public class Transcoding {
      */
     public void setStep3(String step3) {
         this.step3 = step3;
+    }
+
+    /**
+     * Returns whether seeking on streams should be enabled.
+     *
+     * @return Whether seeking on streams should be enabled.
+     */
+    public boolean isEnableSeek() {
+        return enableSeek;
+    }
+
+    /**
+     * Sets whether seeking on streams should be enabled.
+     *
+     * @param enableSeek Whether seeking on streams should be enabled.
+     */
+    public void setEnableSeek(boolean enableSeek) {
+        this.enableSeek = enableSeek;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
@@ -109,7 +109,7 @@ public class JukeboxLegacySubsonicService implements AudioPlayer.Listener {
                     int duration = file.getDurationSeconds() == null ? 0 : file.getDurationSeconds() - offset;
                     TranscodingService.Parameters parameters = new TranscodingService.Parameters(file, new VideoTranscodingSettings(0, 0, offset, duration, false));
                     String command = settingsService.getJukeboxCommand();
-                    parameters.setTranscoding(new Transcoding(null, null, null, null, command, null, null, false));
+                    parameters.setTranscoding(new Transcoding(null, null, null, null, command, null, null, false, true));
                     in = transcodingService.getTranscodedInputStream(parameters);
                     audioPlayer = new AudioPlayer(in, this);
                     audioPlayer.setGain(gain);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -84,6 +84,7 @@ public class SettingsService {
     private static final String KEY_DOWNLOAD_BITRATE_LIMIT = "DownloadBitrateLimit";
     private static final String KEY_UPLOAD_BITRATE_LIMIT = "UploadBitrateLimit";
     private static final String KEY_DOWNSAMPLING_COMMAND = "DownsamplingCommand4";
+    private static final String KEY_DOWNSAMPLING_ENABLE_SEEK = "DownsamplingEnableSeek1";
     private static final String KEY_HLS_COMMAND = "HlsCommand3";
     private static final String KEY_JUKEBOX_COMMAND = "JukeboxCommand2";
     private static final String KEY_VIDEO_IMAGE_COMMAND = "VideoImageCommand";
@@ -162,6 +163,7 @@ public class SettingsService {
     private static final long DEFAULT_DOWNLOAD_BITRATE_LIMIT = 0;
     private static final long DEFAULT_UPLOAD_BITRATE_LIMIT = 0;
     private static final String DEFAULT_DOWNSAMPLING_COMMAND = "ffmpeg -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -";
+    private static final boolean DEFAULT_DOWNSAMPLING_ENABLE_SEEK = true;
     private static final String DEFAULT_HLS_COMMAND = "ffmpeg -ss %o -t %d -i %s -async 1 -b:v %bk -s %wx%h -ar 44100 -ac 2 -v 0 -f mpegts -c:v libx264 -preset superfast -c:a libmp3lame -threads 0 -";
     private static final String DEFAULT_JUKEBOX_COMMAND = "ffmpeg -ss %o -i %s -map 0:0 -v 0 -ar 44100 -ac 2 -f s16be -";
     private static final String DEFAULT_VIDEO_IMAGE_COMMAND = "ffmpeg -r 1 -ss %o -t 1 -i %s -s %wx%h -v 0 -f mjpeg -";
@@ -619,6 +621,14 @@ public class SettingsService {
 
     public void setDownsamplingCommand(String command) {
         setProperty(KEY_DOWNSAMPLING_COMMAND, command);
+    }
+
+    public boolean isDownsamplingEnableSeek() {
+        return getBoolean(KEY_DOWNSAMPLING_ENABLE_SEEK, DEFAULT_DOWNSAMPLING_ENABLE_SEEK);
+    }
+
+    public void setDownsamplingEnableSeek(boolean enableSeek) {
+        setBoolean(KEY_DOWNSAMPLING_ENABLE_SEEK, enableSeek);
     }
 
     public String getHlsCommand() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
@@ -198,10 +198,12 @@ public class TranscodingService {
             maxBitRate = transcodeScheme.getMaxBitRate();
         }
 
+        boolean enableSeek = true;
         boolean hls = videoTranscodingSettings != null && videoTranscodingSettings.isHls();
         Transcoding transcoding = getTranscoding(mediaFile, player, preferredTargetFormat, hls);
         if (transcoding != null) {
             parameters.setTranscoding(transcoding);
+            enableSeek &= transcoding.isEnableSeek();
             if (maxBitRate == null) {
                 maxBitRate = mediaFile.isVideo() ? VideoPlayerController.DEFAULT_BIT_RATE : TranscodeScheme.MAX_192.getMaxBitRate();
             }
@@ -210,10 +212,12 @@ public class TranscodingService {
             Integer bitRate = mediaFile.getBitRate();
             if (supported && bitRate != null && bitRate > maxBitRate) {
                 parameters.setDownsample(true);
+                enableSeek &= settingsService.isDownsamplingEnableSeek();
             }
         }
 
         parameters.setMaxBitRate(maxBitRate);
+        parameters.setEnableSeek(enableSeek);
         return parameters;
     }
 
@@ -391,7 +395,7 @@ public class TranscodingService {
     private Transcoding getTranscoding(MediaFile mediaFile, Player player, String preferredTargetFormat, boolean hls) {
 
         if (hls) {
-            return new Transcoding(null, "hls", mediaFile.getFormat(), "ts", settingsService.getHlsCommand(), null, null, true);
+            return new Transcoding(null, "hls", mediaFile.getFormat(), "ts", settingsService.getHlsCommand(), null, null, true, true);
         }
 
         if (FORMAT_RAW.equals(preferredTargetFormat)) {
@@ -517,6 +521,7 @@ public class TranscodingService {
         private final VideoTranscodingSettings videoTranscodingSettings;
         private Integer maxBitRate;
         private Transcoding transcoding;
+        private boolean enableSeek;
 
         public Parameters(MediaFile mediaFile, VideoTranscodingSettings videoTranscodingSettings) {
             this.mediaFile = mediaFile;
@@ -557,6 +562,14 @@ public class TranscodingService {
 
         public VideoTranscodingSettings getVideoTranscodingSettings() {
             return videoTranscodingSettings;
+        }
+
+        public void setEnableSeek(boolean enableSeek) {
+            this.enableSeek = enableSeek;
+        }
+
+        public boolean isEnableSeek() {
+            return enableSeek;
         }
     }
 }

--- a/airsonic-main/src/main/resources/liquibase/6.3/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/6.3/changelog.xml
@@ -4,4 +4,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <include file="add-player-mixer.xml" relativeToChangelogFile="true"/>
     <include file="mediaelement.xml" relativeToChangelogFile="true"/>
+    <include file="trancoding-enable-seek.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/6.3/trancoding-enable-seek.xml
+++ b/airsonic-main/src/main/resources/liquibase/6.3/trancoding-enable-seek.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="trancoding-enable-seek_001" author="willypillow">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="transcoding2" columnName="enable_seek" />
+            </not>
+        </preConditions>
+        <addColumn tableName="transcoding2">
+            <column name="enable_seek" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -415,6 +415,7 @@ transcodingsettings.step2=Step 2
 transcodingsettings.step3=Step 3
 transcodingsettings.add=Add transcoding
 transcodingsettings.defaultactive=Enable transcoding settings for all existing and new players.
+transcodingsettings.enableseek=Enable seeking
 transcodingsettings.recommended=Recommended configuration
 transcodingsettings.noname=Please specify a name.
 transcodingsettings.nosourceformat=Please specify the format to convert from.

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
@@ -22,6 +22,7 @@
         <th><fmt:message key="transcodingsettings.targetformat"/></th>
         <th><fmt:message key="transcodingsettings.step1"/></th>
         <th><fmt:message key="transcodingsettings.step2"/></th>
+        <th style="padding-left:1em"><fmt:message key="transcodingsettings.enableseek"/></th>
         <th style="padding-left:1em"><fmt:message key="common.delete"/></th>
     </tr>
 
@@ -32,6 +33,7 @@
             <td><input style="font-family:monospace" type="text" name="targetFormat[${transcoding.id}]" size="10" value="${transcoding.targetFormat}"/></td>
             <td><input style="font-family:monospace" type="text" name="step1[${transcoding.id}]" size="60" value="${transcoding.step1}"/></td>
             <td><input style="font-family:monospace" type="text" name="step2[${transcoding.id}]" size="22" value="${transcoding.step2}"/></td>
+            <td align="center" style="padding-left:1em"><input type="checkbox" name="enableSeek[${transcoding.id}]" class="checkbox" ${transcoding.enableSeek ? "checked" : ""}/></td>
             <td align="center" style="padding-left:1em"><input type="checkbox" name="delete[${transcoding.id}]" class="checkbox"/></td>
         </tr>
     </c:forEach>
@@ -66,6 +68,10 @@
             </td>
             <td>
                 <input style="font-family:monospace" type="text" name="downsampleCommand" size="100" value="${model.downsampleCommand}"/>
+            </td>
+            <td>
+                <input type="checkbox" id="enableSeek" name="enableSeek" class="checkbox" ${model.downsamplingEnableSeek ? "checked" : ""}/>
+                <label for="enableSeek"><fmt:message key="transcodingsettings.enableseek"/></label>
             </td>
         </tr>
         <tr>

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/TranscodingDaoTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/TranscodingDaoTestCase.java
@@ -30,7 +30,7 @@ public class TranscodingDaoTestCase extends DaoTestCaseBean2 {
 
     @Test
     public void testCreateTranscoding() {
-        Transcoding transcoding = new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false);
+        Transcoding transcoding = new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false, true);
         transcodingDao.createTranscoding(transcoding);
 
         Transcoding newTranscoding = transcodingDao.getAllTranscodings().get(0);
@@ -39,7 +39,7 @@ public class TranscodingDaoTestCase extends DaoTestCaseBean2 {
 
     @Test
     public void testUpdateTranscoding() {
-        Transcoding transcoding = new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false);
+        Transcoding transcoding = new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false, true);
         transcodingDao.createTranscoding(transcoding);
         transcoding = transcodingDao.getAllTranscodings().get(0);
 
@@ -60,10 +60,10 @@ public class TranscodingDaoTestCase extends DaoTestCaseBean2 {
     public void testDeleteTranscoding() {
         assertEquals("Wrong number of transcodings.", 0, transcodingDao.getAllTranscodings().size());
 
-        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", true));
+        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", true, true));
         assertEquals("Wrong number of transcodings.", 1, transcodingDao.getAllTranscodings().size());
 
-        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", true));
+        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", true, true));
         assertEquals("Wrong number of transcodings.", 2, transcodingDao.getAllTranscodings().size());
 
         transcodingDao.deleteTranscoding(transcodingDao.getAllTranscodings().get(0).getId());
@@ -78,9 +78,9 @@ public class TranscodingDaoTestCase extends DaoTestCaseBean2 {
         Player player = new Player();
         playerDao.createPlayer(player);
 
-        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false));
-        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false));
-        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false));
+        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false, true));
+        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false, true));
+        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", false, true));
         Transcoding transcodingA = transcodingDao.getAllTranscodings().get(0);
         Transcoding transcodingB = transcodingDao.getAllTranscodings().get(1);
         Transcoding transcodingC = transcodingDao.getAllTranscodings().get(2);
@@ -109,7 +109,7 @@ public class TranscodingDaoTestCase extends DaoTestCaseBean2 {
         Player player = new Player();
         playerDao.createPlayer(player);
 
-        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", true));
+        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", true, true));
         Transcoding transcoding = transcodingDao.getAllTranscodings().get(0);
 
         transcodingDao.setTranscodingsForPlayer(player.getId(), new int[]{transcoding.getId()});
@@ -126,7 +126,7 @@ public class TranscodingDaoTestCase extends DaoTestCaseBean2 {
         Player player = new Player();
         playerDao.createPlayer(player);
 
-        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", true));
+        transcodingDao.createTranscoding(new Transcoding(null, "name", "sourceFormats", "targetFormat", "step1", "step2", "step3", true, true));
         Transcoding transcoding = transcodingDao.getAllTranscodings().get(0);
 
         transcodingDao.setTranscodingsForPlayer(player.getId(), new int[]{transcoding.getId()});


### PR DESCRIPTION
As per #548, #723, and tsquillario/Jamstash#131, the current method of
estimating `Content-Length` creates various problems.

However, if headers such as `Accept-Ranges` is omitted, clients will only
use the first connection, which is `Transfer-Encoding: chunked`, and no
`Content-Length` is necessary.

Doing this has the side effect that (at least on the web player) seeking
to a specific time is no longer possible, thus this was made an opt-in
option.

Signed-off-by: WillyPillow <wp@nerde.pw>