### PR TITLE
Suppress CVE-2018-13684 for dependency-check

### DIFF
--- a/airsonic-main/cve-suppressed.xml
+++ b/airsonic-main/cve-suppressed.xml
@@ -129,4 +129,9 @@
         <gav regex="true">^org\.mariadb\.jdbc:mariadb-java-client:.*$</gav>
         <cve>CVE-2017-16046</cve>
     </suppress>
+    <suppress>
+       <notes><![CDATA[file name: ant-zip-1.6.2.jar]]></notes>
+       <gav regex="true">^ant-zip:ant-zip:.*$</gav>
+       <cve>CVE-2018-13684</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
False positive matching ant-zip against a CVE for ZIP, an Ethereum token.