### PR TITLE
Don't use HTTPS for scrobbling

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/AudioScrobblerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/AudioScrobblerService.java
@@ -175,7 +175,7 @@ public class AudioScrobblerService {
         String clientVersion = "0.1";
         long timestamp = System.currentTimeMillis() / 1000L;
         String authToken = calculateAuthenticationToken(registrationData.password, timestamp);
-        URI uri = new URI("https",
+        URI uri = new URI("http",
                 /* userInfo= */ null, "post.audioscrobbler.com", -1,
                 "/",
                 String.format("hs=true&p=1.2.1&c=%s&v=%s&u=%s&t=%s&a=%s",


### PR DESCRIPTION
Turns out HTTPS isn't supported for the old API that we're using, so go back to using plain HTTP.

The API just returns a "look at the API documentation" message when we use HTTPS, but plain HTTP works.