### PR TITLE
Use dark media player theme on Groove theme

### DIFF
--- a/airsonic-main/src/main/webapp/style/groove.css
+++ b/airsonic-main/src/main/webapp/style/groove.css
@@ -13,7 +13,8 @@
  * Main theme icon part of itunes icon pack created by Michael Flarup (http://pixelresort.com)
  */
 
-@import "default.css";
+@import "default-without-mediaelement.css";
+@import "mediaelement-dark.css";
 
 /* The primary background colour. */
 .bgcolor1, table.music tr:nth-of-type(even) {


### PR DESCRIPTION
The "Groove" theme currently uses the black-on-black icons for the media player, which are not so easy to see.