### PR TITLE
Optionally parse podcast episode duration in seconds to [hh:]mm:ss

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -422,7 +422,7 @@ public class PodcastService {
         for (Element episodeElement : episodeElements) {
 
             String title = episodeElement.getChildTextTrim("title");
-            String duration = getITunesElement(episodeElement, "duration");
+            String duration = formatDuration(getITunesElement(episodeElement, "duration"));
             String description = episodeElement.getChildTextTrim("description");
             if (StringUtils.isBlank(description)) {
                 description = getITunesElement(episodeElement, "summary");
@@ -500,6 +500,19 @@ public class PodcastService {
         }
         LOG.warn("Failed to parse publish date: '" + s + "'.");
         return null;
+    }
+
+    private String formatDuration(String duration) {
+        if (duration == null) return null;
+        if (duration.matches("^\\d+$")) {
+            long seconds = Long.valueOf(duration);
+            if (seconds >= 3600)
+                return String.format("%02d:%02d:%02d", seconds / 3600, seconds / 60, seconds % 60);
+            else
+                return String.format("%02d:%02d", seconds / 60, seconds % 60);
+        } else {
+            return duration;
+        }
     }
 
     private String getITunesElement(Element element, String childName) {


### PR DESCRIPTION
In podcasts, the attribute `itunes:duration` provides (normally) a string formatted like [hh:]mm:ss, but some sources choose to format that property as showing the seconds only, so for example it'd be 639 instead of 10:39.

I have added an extra step when retrieving the duration to convert the seconds to the aforementioned human-readable format.