### PR TITLE
Fix test failure on Windows from inconsistent path strings

### DIFF
--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -125,10 +125,10 @@ public class MediaScannerServiceTestCase {
 
 
         // Music Folder Music must have 3 children
-        List<MediaFile> listeMusicChildren = mediaFileDao.getChildrenOf(MusicFolderTestData.resolveMusicFolderPath());
+        List<MediaFile> listeMusicChildren = mediaFileDao.getChildrenOf(new File(MusicFolderTestData.resolveMusicFolderPath()).getPath());
         Assert.assertEquals(3, listeMusicChildren.size());
         // Music Folder Music2 must have 1 children
-        List<MediaFile> listeMusic2Children = mediaFileDao.getChildrenOf(MusicFolderTestData.resolveMusic2FolderPath());
+        List<MediaFile> listeMusic2Children = mediaFileDao.getChildrenOf(new File(MusicFolderTestData.resolveMusic2FolderPath()).getPath());
         Assert.assertEquals(1, listeMusic2Children.size());
 
         System.out.println("--- List of all artists ---");


### PR DESCRIPTION
Media directories are added to the test database with the string essentially generated by this code:
`new File(MusicFolderTestData.resolveMusicFolderPath()).getPath()`

The directories are then queried by the string generated by this code:
`MusicFolderTestData.resolveMusicFolderPath()`

The strings are different on Windows.
`MusicFolderTestData.resolveMusicFolderPath()`
is prefixed by an extra slash that is removed when wrapped by a `File()`.
