### PR TITLE
Allow building without Git

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -549,6 +549,7 @@
                 <configuration>
                     <doCheck>false</doCheck>
                     <doUpdate>false</doUpdate>
+                    <revisionOnScmFailure>Unversioned</revisionOnScmFailure>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
If Maven cannot find the git executable the build fails.
