### PR TITLE
Fixed Github link opening in frame and not loading

### DIFF
--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -279,7 +279,7 @@ help.homepage.title=Homepage
 help.forum.title=Forum
 help.shop.title=Merchandise
 help.contact.title=Contact
-help.contact.text=Airsonic is a community project. You can find us in <a href="irc://chat.freenode.net/airsonic">#airsonic on Freenode</a>. Technical issues can be submitted to the <a href="https://github.com/airsonic/airsonic/issues">issue tracker on GitHub</a>.
+help.contact.text=Airsonic is a community project. You can find us in <a href="irc://chat.freenode.net/airsonic">#airsonic on Freenode</a>. Technical issues can be submitted to the <a href="https://github.com/airsonic/airsonic/issues" target="_blank">issue tracker on GitHub</a>.
 help.log=Log
 help.logfile=The complete log is saved in {0}.
 # settingsHeader.jsp

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_TW.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_TW.properties
@@ -319,7 +319,7 @@ help.homepage.title = \u9996\u9801
 help.forum.title = \u8AD6\u58C7
 help.shop.title = \u5546\u54C1
 help.contact.title = \u806F\u7E6B
-help.contact.text = Airsonic \u662F\u793E\u7FA4\u5C08\u6848\u3002 \u60A8\u53EF\u4EE5\u5728 <a href="irc://chat.freenode.net/airsonic">Freenode \u4E0A\u7684 #airsonic</a> \u627E\u5230\u6211\u5011\u3002\u6280\u8853\u554F\u984C\u53EF\u4EE5\u63D0\u4EA4\u5230 <a href="https://github.com/airsonic/airsonic/issues">Github \u4E0A\u7684\u554F\u984C\u8FFD\u8E64\u5668</a>\u3002
+help.contact.text = Airsonic \u662F\u793E\u7FA4\u5C08\u6848\u3002 \u60A8\u53EF\u4EE5\u5728 <a href="irc://chat.freenode.net/airsonic">Freenode \u4E0A\u7684 #airsonic</a> \u627E\u5230\u6211\u5011\u3002\u6280\u8853\u554F\u984C\u53EF\u4EE5\u63D0\u4EA4\u5230 <a href="https://github.com/airsonic/airsonic/issues" target="_blank">Github \u4E0A\u7684\u554F\u984C\u8FFD\u8E64\u5668</a>\u3002
 help.log = \u8A18\u9304
 help.logfile = \u5B8C\u6574\u7684\u7D00\u9304\u5B58\u653E\u5728 {0}\u3002
 


### PR DESCRIPTION
Without the `target="_blank"` the issues linked tried to load in the central frame of the page, and it couldn't, because Github doesn't allow it.

The error was:

    Refused to display 'https://github.com/airsonic/airsonic/issues' in a frame because an ancestor violates the following Content Security Policy directive: "frame-ancestors 'none'".

I searched for the link through the repo, but could only find it in 2 of the locales.