### PR TITLE
Display folders as a list in Settings->Users and include the path.

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/userSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/userSettings.jsp
@@ -108,14 +108,15 @@
     <c:if test="${not empty command.allMusicFolders}">
         <h2><fmt:message key="usersettings.folderaccess"/></h2>
 
-        <div style="width:75%">
+        <table>
             <c:forEach items="${command.allMusicFolders}" var="musicFolder">
-                <span style="white-space:nowrap">
-                    <form:checkbox path="allowedMusicFolderIds" id="musicFolder${musicFolder.id}" value="${musicFolder.id}" cssClass="checkbox"/>
-                    <label for="musicFolder${musicFolder.id}" style="padding-right:1.5em">${musicFolder.name}</label>
-                </span>
+                <tr>
+                    <td><form:checkbox path="allowedMusicFolderIds" id="musicFolder${musicFolder.id}" value="${musicFolder.id}" cssClass="checkbox"/></td>
+                    <td><label for="musicFolder${musicFolder.id}" style="padding-right:1.5em">${musicFolder.name}</label></td>
+                    <td><label for="musicFolder${musicFolder.id}" style="padding-right:1.5em">${musicFolder.path}</label></td>
+                </tr>
             </c:forEach>
-        </div>
+        </table>
     </c:if>
 
     <table class="indent">


### PR DESCRIPTION
Displaying the path is handy for when someone wants to use the same names but have different paths. 

Example:

Music -> /mnt/users/userA/Music
Music -> /mnt/users/userB/Music

