### PR TITLE
Correct corrupted downloaded zip

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -207,6 +207,8 @@ public class DownloadController implements LastModified {
      * @param zipFileName  The name of the resulting zip file.   @throws IOException If an I/O error occurs.
      */
     private void downloadFiles(HttpServletResponse response, TransferStatus status, List<MediaFile> files, int[] indexes, File coverArtFile, HttpRange range, String zipFileName) throws IOException {
+        boolean cover_embedded = false;
+
         if (indexes != null && indexes.length == 1) {
             downloadFile(response, status, files.get(indexes[0]).getFile(), range);
             return;
@@ -232,8 +234,13 @@ public class DownloadController implements LastModified {
 
         for (MediaFile mediaFile : filesToDownload) {
             zip(out, mediaFile.getParentFile(), mediaFile.getFile(), status, range);
+            if (coverArtFile != null && coverArtFile.exists()) {
+                if (mediaFile.getFile().getCanonicalPath() == coverArtFile.getCanonicalPath()) {
+                    cover_embedded = true;
+                }
+            }
         }
-        if (coverArtFile != null && coverArtFile.exists()) {
+        if (coverArtFile != null && coverArtFile.exists() && cover_embedded == false) {
             zip(out, coverArtFile.getParentFile(), coverArtFile, status, range);
         }
 


### PR DESCRIPTION
Prevent the zipping of twice the same file (resulting in an error and a corrupted zip on Linux) when the cover is embedded in tags

This should correct issue #72  and #678 
Tested with Airsonic built from master, running on Mint 18 with the WAR file, downloaded zip are no longer corrupted when opened from windows when cover is embedded in tags.
Both embedded coverArt and in folder coverArt are working.