### PR TITLE
Fix #778: Defragment embedded HSQLDB database more frequently

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/10.2/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.2/changelog.xml
@@ -1,0 +1,6 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <include file="setup-hsqldb-checkpoint-defrag.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/10.2/setup-hsqldb-checkpoint-defrag.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.2/setup-hsqldb-checkpoint-defrag.xml
@@ -9,6 +9,10 @@
         </preConditions>
 
         <sql>
+          CHECKPOINT DEFRAG;
+          <comment>Defragment the database before enabling auto defrag, so that the biggest part of the work is done during migration.</comment>
+        </sql>
+        <sql>
           SET LOGSIZE 64;
           <comment>Automatically run a CHECKPOINT when the log is above 64MB.</comment>
         </sql>

--- a/airsonic-main/src/main/resources/liquibase/10.2/setup-hsqldb-checkpoint-defrag.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.2/setup-hsqldb-checkpoint-defrag.xml
@@ -1,0 +1,23 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="setup-hsqldb-checkpoint-defrag" author="fxthomas">
+
+        <preConditions onFail="MARK_RAN">
+          <dbms type="hsqldb" />
+        </preConditions>
+
+        <sql>
+          SET LOGSIZE 64;
+          <comment>Automatically run a CHECKPOINT when the log is above 64MB.</comment>
+        </sql>
+        <sql>
+          SET CHECKPOINT DEFRAG 32;
+          <comment>Automatically defragment on CHECKPOINT when the wasted space is above 32MB.</comment>
+        </sql>
+
+        <rollback></rollback>
+
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -11,4 +11,5 @@
     <include file="6.2/changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.3/changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.4/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="10.2/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
Hey folks, happy new year!

I finally got around to fixing #778 for those of us using the embedded database. A few things to note before reviewing the code :

* I set the checkpoint size limit to 64MB (from a default of 200MB). This means that the DB will do a checkpoint each time the log ("pending changes") grows above that limit. This seems sane enough for Airsonic, and should not impact performance given the amount of data larger instances handle.
* The defrag limit is set to 32MB of wasted space, checked on each checkpoint. If the wasted space is below 32MB, nothing happens (just a regular checkpoint). This _will_ impact performance while the defrag is happening, because this is an expensive operation (usually below 10s for me, with ~15k songs).
* This is not compatible with HSQLDB 2 (it uses a different syntax), but I'm not sure we need to support it.

This sounds reasonable to me, and works on my instance. Comments are of course welcome!