### PR TITLE
fix #865 JaudiotaggerParser not support APE format

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
@@ -144,7 +144,7 @@ public class FFmpegParser extends MetaDataParser {
                 return true;
             }
         }
-        return false;
+        return "ape".equals(format);
     }
 
     public void setTranscodingService(TranscodingService transcodingService) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -303,7 +303,6 @@ public class JaudiotaggerParser extends MetaDataParser {
                 format.equals("wav") ||
                 format.equals("mpc") ||
                 format.equals("mp+") ||
-                format.equals("ape") ||
                 format.equals("wma");
     }
 


### PR DESCRIPTION
See the detail in #865. We can use FFmpegParser  to parse APE format