### PR TITLE
Support m4b files

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -138,7 +138,7 @@ public class SettingsService {
     private static final String DEFAULT_IGNORED_ARTICLES = "The El La Los Las Le Les";
     private static final String DEFAULT_SHORTCUTS = "New Incoming Podcast";
     private static final String DEFAULT_PLAYLIST_FOLDER = Util.getDefaultPlaylistFolder();
-    private static final String DEFAULT_MUSIC_FILE_TYPES = "mp3 ogg oga aac m4a flac wav wma aif aiff ape mpc shn mka opus";
+    private static final String DEFAULT_MUSIC_FILE_TYPES = "mp3 ogg oga aac m4a m4b flac wav wma aif aiff ape mpc shn mka opus";
     private static final String DEFAULT_VIDEO_FILE_TYPES = "flv avi mpg mpeg mp4 m4v mkv mov wmv ogv divx m2ts";
     private static final String DEFAULT_COVER_ART_FILE_TYPES = "cover.jpg cover.png cover.gif folder.jpg jpg jpeg gif png";
     private static final int DEFAULT_COVER_ART_CONCURRENCY = 4;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -297,6 +297,7 @@ public class JaudiotaggerParser extends MetaDataParser {
 
         return format.equals("mp3") ||
                 format.equals("m4a") ||
+                format.equals("m4b") ||
                 format.equals("aac") ||
                 format.equals("ogg") ||
                 format.equals("flac") ||

--- a/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
@@ -64,6 +64,7 @@ public final class StringUtil {
             {"ogx", "application/ogg"},
             {"aac", "audio/mp4"},
             {"m4a", "audio/mp4"},
+            {"m4b", "audio/mp4"},
             {"flac", "audio/flac"},
             {"wav", "audio/x-wav"},
             {"wma", "audio/x-ms-wma"},


### PR DESCRIPTION
anywhere m4a is referenced in java code add support for m4b as well.

This is in reference to #896 

Just adding m4b to the music file types in the UI did not make m4b files recoginized by the scanner.