### PR TITLE
More informative log messages when streaming

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -492,6 +492,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Provided by the servlet container, but found by dependency:analyze even if used via reflection -->
+        <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-io</artifactId>
+          <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -249,8 +249,8 @@ public class StreamController  {
                     }
                 }
             }
-        } catch (ClientAbortException err) {
-            LOG.info("org.apache.catalina.connector.ClientAbortException: Connection reset");
+        } catch (ClientAbortException e) {
+            LOG.info("{}: Client unexpectedly closed connection while loading {} ({})", request.getRemoteAddr(), Util.getURLForRequest(request), e.getCause().toString());
             return;
         } finally {
             if (status != null) {
@@ -426,5 +426,4 @@ public class StreamController  {
         out.write(buf);
         out.flush();
     }
-
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -108,7 +108,7 @@ public class StreamController  {
                 playQueue.addFiles(false, playlistService.getFilesInPlaylist(playlistId));
                 player.setPlayQueue(playQueue);
                 Util.setContentLength(response, playQueue.length());
-                LOG.info("Incoming Podcast request for playlist " + playlistId);
+                LOG.info("{}: Incoming Podcast request for playlist {}", request.getRemoteAddr(), playlistId);
             }
 
             response.setHeader("Access-Control-Allow-Origin", "*");
@@ -165,7 +165,7 @@ public class StreamController  {
 
                 range = getRange(request, file);
                 if (settingsService.isEnableSeek() && range != null && !file.isVideo()) {
-                    LOG.info("Got HTTP range: " + range);
+                    LOG.info("{}: Got HTTP range: {}", request.getRemoteAddr(), range);
                     response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
                     Util.setContentLength(response, range.isClosed() ? range.size() : fileLength - range.getFirstBytePos());
                     long lastBytePos = range.getLastBytePos() != null ? range.getLastBytePos() : fileLength - 1;

--- a/airsonic-main/src/main/java/org/airsonic/player/io/PlayQueueInputStream.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/PlayQueueInputStream.java
@@ -117,7 +117,7 @@ public class PlayQueueInputStream extends InputStream {
             close();
         } else if (!file.equals(currentFile)) {
             close();
-            LOG.info(player.getUsername() + " listening to \"" + FileUtil.getShortPath(file.getFile()) + "\"");
+            LOG.info("{}: {} listening to {}", player.getIpAddress(), player.getUsername(), FileUtil.getShortPath(file.getFile()));
             mediaFileService.incrementPlayCount(file);
 
             // Don't scrobble REST players (except Sonos)

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/LoggingExceptionResolver.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/LoggingExceptionResolver.java
@@ -1,5 +1,6 @@
 package org.airsonic.player.spring;
 
+import org.airsonic.player.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
@@ -11,13 +12,17 @@ import javax.servlet.http.HttpServletResponse;
 
 public class LoggingExceptionResolver implements HandlerExceptionResolver, Ordered {
 
-    private static final Logger logger = LoggerFactory.getLogger(LoggingExceptionResolver.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingExceptionResolver.class);
 
     @Override
     public ModelAndView resolveException(
-            HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object o, Exception e
+            HttpServletRequest request, HttpServletResponse response, Object o, Exception e
     ) {
-        logger.error("Exception occurred", e);
+        if (e instanceof org.apache.catalina.connector.ClientAbortException) {
+            LOG.info("{}: Client unexpectedly closed connection while loading {} ({})", request.getRemoteAddr(), Util.getURLForRequest(request), e.getCause().toString());
+        } else {
+            LOG.error("{}: An exception occurred while loading {}", request.getRemoteAddr(), Util.getURLForRequest(request), e);
+        }
         return null;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/util/Util.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/Util.java
@@ -132,4 +132,16 @@ public final class Util {
         if (queryString != null && queryString.length() > 0) url += "?" + queryString;
         return url;
     }
+
+    /**
+     * Return true if the given object is an instance of the class name in argument.
+     * If the class doesn't exist, returns false.
+     */
+    public static boolean isInstanceOfClassName(Object o, String className) {
+        try {
+            return Class.forName(className).isInstance(o);
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/util/Util.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/Util.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.util.ArrayList;
@@ -116,5 +117,19 @@ public final class Util {
             LOG.warn("Cant output debug object", e);
             return "";
         }
+    }
+
+    /**
+     * Return a complete URL for the given HTTP request,
+     * including the query string.
+     *
+     * @param request An HTTP request instance
+     * @return The associated URL
+     */
+    public static String getURLForRequest(HttpServletRequest request) {
+        String url = request.getRequestURL().toString();
+        String queryString = request.getQueryString();
+        if (queryString != null && queryString.length() > 0) url += "?" + queryString;
+        return url;
     }
 }


### PR DESCRIPTION
This small PR makes the log messages more informative and less verbose:

* Add the remote IP address to streaming requests so that we know which client this came from
* Do not show verbose stack traces when the client closes connection by itself (but still show them for other kind of exceptions)

The logs now look like this (they used to be littered with stack traces):

```
2019-03-10 21:44:28.831  INFO --- o.a.p.service.VersionService             : Resolved local Airsonic version to: 10.3.0-SNAPSHOT
2019-03-10 21:44:30.776  INFO --- o.a.p.s.LoggingExceptionResolver         : 127.0.0.1: Client unexpectedly closed connection while loading http://localhost:8080/airsonic/style/smoothness/jquery-ui-1.8.18.custom.css (java.io.IOException: Broken pipe)
2019-03-10 21:44:30.797  INFO --- o.a.p.s.LoggingExceptionResolver         : 127.0.0.1: Client unexpectedly closed connection while loading http://localhost:8080/airsonic/script/jquery-1.7.1.min.js (java.io.IOException: Broken pipe)
2019-03-10 21:44:32.019  INFO --- o.a.p.s.LoggingExceptionResolver         : 127.0.0.1: Client unexpectedly closed connection while loading http://localhost:8080/airsonic/script/moment-2.18.1.min.js (java.io.IOException: Broken pipe)
2019-03-10 21:44:32.033  INFO --- o.a.p.s.LoggingExceptionResolver         : 127.0.0.1: Client unexpectedly closed connection while loading http://localhost:8080/airsonic/script/mediaelement/mediaelement-and-player.min.js (java.io.IOException: Broken pipe)
2019-03-10 21:44:55.039  INFO --- o.a.p.c.StreamController                 : 127.0.0.1: Got HTTP range: 0-
2019-03-10 21:44:55.051  INFO --- o.a.p.io.PlayQueueInputStream            : 127.0.0.1: admin listening to SUPERMAN/01 アラジン.flac
2019-03-10 21:44:56.927  INFO --- o.a.p.c.StreamController                 : 127.0.0.1: Client unexpectedly closed connection while loading http://localhost:8080/airsonic/stream?player=1&id=3 (java.io.IOException: Connection reset by peer)
```