### PR TITLE
Add some checks to avoid stackstrace

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -150,7 +150,12 @@ public class CoverArtController implements LastModified {
         if (id.startsWith(PODCAST_COVERART_PREFIX)) {
             return createPodcastCoverArtRequest(Integer.valueOf(id.replace(PODCAST_COVERART_PREFIX, "")), request);
         }
-        return createMediaFileCoverArtRequest(Integer.valueOf(id), request);
+        try {
+            return createMediaFileCoverArtRequest(Integer.valueOf(id), request);
+        } catch (java.lang.NumberFormatException x) {
+            LOG.warn("Invalid cover id: " + id, x.toString());
+            return null;
+        }
     }
 
     private CoverArtRequest createAlbumCoverArtRequest(int id) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/PlayerSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/PlayerSettingsController.java
@@ -26,6 +26,8 @@ import org.airsonic.player.service.PlayerService;
 import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.TranscodingService;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -50,6 +52,8 @@ import java.util.List;
 @Controller
 @RequestMapping("/playerSettings")
 public class PlayerSettingsController  {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PlayerSettingsController.class);
 
     @Autowired
     private PlayerService playerService;
@@ -153,9 +157,21 @@ public class PlayerSettingsController  {
 
     private void handleRequestParameters(HttpServletRequest request) throws Exception {
         if (request.getParameter("delete") != null) {
-            playerService.removePlayerById(ServletRequestUtils.getIntParameter(request, "delete"));
+            Integer id = ServletRequestUtils.getIntParameter(request, "delete");
+            try {
+                playerService.removePlayerById(id);
+            } catch (java.lang.NumberFormatException x) {
+                LOG.warn("Invalid player id: " + id, x);
+                return;
+            }
         } else if (request.getParameter("clone") != null) {
-            playerService.clonePlayer(ServletRequestUtils.getIntParameter(request, "clone"));
+            Integer id = ServletRequestUtils.getIntParameter(request, "clone");
+            try {
+                playerService.clonePlayer(id);
+            } catch (java.lang.NumberFormatException x) {
+                LOG.warn("Invalid player id: " + id, x);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
Blindly casting to integer without a try-catch
can lead to a stacktrace for some values.

Signed-off-by: jvoisin <julien.voisin@dustri.org>
