### PR TITLE
Fix a javascript null-deref

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/more.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/more.jsp
@@ -60,6 +60,7 @@
             try {
                 var data = JSON.parse(localStorage.getItem("randomPlayQueue"));
             } catch(e) { return; }
+            if (data == null ) { return; }
             elements = form.getElementsByTagName("input");
             for (var i = 0; i < elements.length; i++) {
                 if (elements[i].type == "hidden") continue;


### PR DESCRIPTION
This commit should fix the following javascript crash that
may occur if the localstorage isn't available/supported by the browser:

```js
more.view:140 Uncaught TypeError: Cannot read property 'playCountValue' of null
    at loadShuffleForm (more.view:140)
    at HTMLDocument.<anonymous> (more.view:181)
    at n (jquery-1.7.1.min.js:2)
    at Object.fireWith (jquery-1.7.1.min.js:2)
    at Function.ready (jquery-1.7.1.min.js:2)
    at HTMLDocument.B (jquery-1.7.1.min.js:2)
```

Signed-off-by: jvoisin <julien.voisin@dustri.org>
