### PR TITLE
Java5 deprecation

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/TagService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/TagService.java
@@ -73,7 +73,7 @@ public class TagService {
         Integer trackNumber = null;
         if (track != null) {
             try {
-                trackNumber = new Integer(track);
+                trackNumber = Integer.valueOf(track);
             } catch (NumberFormatException x) {
                 LOG.warn("Illegal track number: " + track, x);
             }
@@ -82,7 +82,7 @@ public class TagService {
         Integer yearNumber = null;
         if (year != null) {
             try {
-                yearNumber = new Integer(year);
+                yearNumber = Integer.valueOf(year);
             } catch (NumberFormatException x) {
                 LOG.warn("Illegal year: " + year, x);
             }

--- a/airsonic-main/src/main/java/org/airsonic/player/command/UserSettingsCommand.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/command/UserSettingsCommand.java
@@ -295,7 +295,7 @@ public class UserSettingsCommand {
         isSettingsRole = user != null && user.isSettingsRole();
         isShareRole = user != null && user.isShareRole();
         isLdapAuthenticated = user != null && user.isLdapAuthenticated();
-        setNewUser(false);
+        isNewUser = false;
     }
 
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -368,9 +368,8 @@ public class DownloadController implements LastModified {
      */
     private long computeCrc(File file) throws IOException {
         CRC32 crc = new CRC32();
-        InputStream in = new FileInputStream(file);
 
-        try {
+        try (InputStream in = new FileInputStream(file)) {
 
             byte[] buf = new byte[8192];
             int n = in.read(buf);
@@ -379,8 +378,6 @@ public class DownloadController implements LastModified {
                 n = in.read(buf);
             }
 
-        } finally {
-            in.close();
         }
 
         return crc.getValue();

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/PlayerSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/PlayerSettingsController.java
@@ -106,8 +106,9 @@ public class PlayerSettingsController  {
         command.setAdmin(user.isAdminRole());
 
         command.setJavaJukeboxMixers(Arrays.stream(AudioSystemUtils.listAllMixers()).map(info -> info.getName()).toArray(String[]::new));
-        command.setJavaJukeboxMixer(player.getJavaJukeboxMixer());
-
+        if (player != null) {
+            command.setJavaJukeboxMixer(player.getJavaJukeboxMixer());
+        }
         model.addAttribute("command",command);
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
@@ -166,9 +166,7 @@ public class UploadController {
     private void unzip(File file, List<File> unzippedFiles) throws Exception {
         LOG.info("Unzipping " + file);
 
-        ZipFile zipFile = new ZipFile(file);
-
-        try {
+        try (ZipFile zipFile = new ZipFile(file)) {
 
             Enumeration<?> entries = zipFile.entries();
 
@@ -210,8 +208,6 @@ public class UploadController {
             zipFile.close();
             file.delete();
 
-        } finally {
-            zipFile.close();
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MusicIndex.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MusicIndex.java
@@ -24,6 +24,7 @@ import java.text.CollationKey;
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A music index is a mapping from an index string to a list of prefixes.  A complete index consists of a list of
@@ -99,7 +100,7 @@ public class MusicIndex implements Serializable {
 
         final MusicIndex musicIndex = (MusicIndex) o;
 
-        if (index != null ? !index.equals(musicIndex.index) : musicIndex.index != null) {
+        if (!Objects.equals(index, musicIndex.index)) {
             return false;
         }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/PlayQueue.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/PlayQueue.java
@@ -215,9 +215,7 @@ public class PlayQueue {
         }
         files.remove(index);
 
-        if (index != -1) {
-            this.index = Math.max(0, Math.min(this.index, size() - 1));
-        }
+        this.index = Math.max(0, Math.min(this.index, size() - 1));
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/TranscodeScheme.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/TranscodeScheme.java
@@ -85,7 +85,7 @@ public enum TranscodeScheme {
         if (this == OFF) {
             return "No limit";
         }
-        return "" + getMaxBitRate() + " Kbps";
+        return getMaxBitRate() + " Kbps";
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Transcoding.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Transcoding.java
@@ -21,6 +21,8 @@ package org.airsonic.player.domain;
 
 import org.airsonic.player.util.StringUtil;
 
+import java.util.Objects;
+
 /**
  * Contains the configuration for a transcoding, i.e., a specification of how a given media format
  * should be converted to another.
@@ -213,7 +215,7 @@ public class Transcoding {
         }
 
         Transcoding that = (Transcoding) o;
-        return !(id != null ? !id.equals(that.id) : that.id != null);
+        return Objects.equals(id, that.id);
     }
 
     public int hashCode() {

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
@@ -234,8 +234,8 @@ public class TransferStatus {
         this.active = active;
 
         if (active) {
-            setBytesSkipped(0L);
-            setBytesTotal(0L);
+            bytesSkipped = 0L;
+            bytesTotal = 0L;
             setBytesTransfered(0L);
         } else {
             createSample(getBytesTransfered(), true);
@@ -281,10 +281,9 @@ public class TransferStatus {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("TransferStatus-").append(hashCode()).append(" [player: ").append(player.getId()).append(", file: ");
-        builder.append(file).append(", terminated: ").append(terminated).append(", active: ").append(active).append("]");
-        return builder.toString();
+        String builder = "TransferStatus-" + hashCode() + " [player: " + player.getId() + ", file: " +
+                file + ", terminated: " + terminated + ", active: " + active + "]";
+        return builder;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/User.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/User.java
@@ -206,7 +206,7 @@ public class User {
 
     @Override
     public String toString() {
-        StringBuffer result = new StringBuffer(username);
+        StringBuilder result = new StringBuilder(username);
 
         if (isAdminRole) {
             result.append(" [admin]");

--- a/airsonic-main/src/main/java/org/airsonic/player/io/TranscodeInputStream.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/TranscodeInputStream.java
@@ -56,7 +56,7 @@ public class TranscodeInputStream extends InputStream {
     public TranscodeInputStream(ProcessBuilder processBuilder, final InputStream in, File tmpFile) throws IOException {
         this.tmpFile = tmpFile;
 
-        StringBuffer buf = new StringBuffer("Starting transcoder: ");
+        StringBuilder buf = new StringBuilder("Starting transcoder: ");
         for (String s : processBuilder.command()) {
             buf.append('[').append(s).append("] ");
         }

--- a/airsonic-main/src/main/java/org/airsonic/player/monitor/MetricsManager.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/monitor/MetricsManager.java
@@ -49,7 +49,7 @@ public class MetricsManager {
                 }
             }
         }
-        return metricsActivatedByConfiguration.booleanValue();
+        return metricsActivatedByConfiguration;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/LastFmService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/LastFmService.java
@@ -183,9 +183,8 @@ public class LastFmService {
      */
     public List<MediaFile> getSimilarSongs(org.airsonic.player.domain.Artist artist, int count,
                                            List<MusicFolder> musicFolders) throws IOException {
-        List<MediaFile> similarSongs = new ArrayList<MediaFile>();
 
-        similarSongs.addAll(mediaFileDao.getSongsByArtist(artist.getName(), 0, 1000));
+        List<MediaFile> similarSongs = new ArrayList<MediaFile>(mediaFileDao.getSongsByArtist(artist.getName(), 0, 1000));
         for (org.airsonic.player.domain.Artist similarArtist : getSimilarArtists(artist, 100, false, musicFolders)) {
             similarSongs.addAll(mediaFileDao.getSongsByArtist(similarArtist.getName(), 0, 1000));
         }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -347,10 +347,6 @@ public class MediaFileService {
     /**
      * Returns random songs matching search criteria.
      *
-     * @param criteria Random search criteria.
-     * @param count    Max number of songs to return.
-     * @return Random songs
-     * @see SearchService.getRandomSongs
      */
     public List<MediaFile> getRandomSongs(RandomSearchCriteria criteria, String username) {
         return mediaFileDao.getRandomSongs(criteria, username);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MusicIndexService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MusicIndexService.java
@@ -265,13 +265,7 @@ public class MusicIndexService {
                 indexB = Integer.MAX_VALUE;
             }
 
-            if (indexA < indexB) {
-                return -1;
-            }
-            if (indexA > indexB) {
-                return 1;
-            }
-            return 0;
+            return Integer.compare(indexA, indexB);
         }
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -450,7 +450,7 @@ public class PodcastService {
             if (getEpisodeByUrl(url) == null) {
                 Long length = null;
                 try {
-                    length = new Long(enclosure.getAttributeValue("length"));
+                    length = Long.valueOf(enclosure.getAttributeValue("length"));
                 } catch (Exception x) {
                     LOG.warn("Failed to parse enclosure length.", x);
                 }
@@ -470,13 +470,7 @@ public class PodcastService {
                 long timeA = a.getPublishDate() == null ? 0L : a.getPublishDate().getTime();
                 long timeB = b.getPublishDate() == null ? 0L : b.getPublishDate().getTime();
 
-                if (timeA < timeB) {
-                    return 1;
-                }
-                if (timeA > timeB) {
-                    return -1;
-                }
-                return 0;
+                return Long.compare(timeB, timeA);
             }
         });
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -96,8 +96,8 @@ public class SecurityService implements UserDetailsService {
         List<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority("IS_AUTHENTICATED_ANONYMOUSLY"));
         authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
-        for (int i = 0; i < roles.length; i++) {
-            authorities.add(new SimpleGrantedAuthority("ROLE_" + roles[i].toUpperCase()));
+        for (String role : roles) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role.toUpperCase()));
         }
         return authorities;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -606,7 +606,7 @@ public class SettingsService {
      * @param limit The download bitrate limit in Kbit/s. Zero if unlimited.
      */
     public void setDownloadBitrateLimit(long limit) {
-        setProperty(KEY_DOWNLOAD_BITRATE_LIMIT, "" + limit);
+        setProperty(KEY_DOWNLOAD_BITRATE_LIMIT, String.valueOf(limit));
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SonosService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SonosService.java
@@ -464,7 +464,7 @@ public class SonosService implements SonosSoap {
             if (StringUtils.isNumeric(part)) {
                 result.add(Integer.parseInt(part));
             } else {
-                int dashIndex = part.indexOf("-");
+                int dashIndex = part.indexOf('-');
                 int from = Integer.parseInt(part.substring(0, dashIndex));
                 int to = Integer.parseInt(part.substring(dashIndex + 1));
                 for (int i = from; i <= to; i++) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -161,7 +161,7 @@ public class JaudiotaggerParser extends MetaDataParser {
         Integer result = null;
 
         try {
-            result = new Integer(trackNumber);
+            result = Integer.valueOf(trackNumber);
         } catch (NumberFormatException x) {
             Matcher matcher = TRACK_NUMBER_PATTERN.matcher(trackNumber);
             if (matcher.matches()) {
@@ -187,7 +187,7 @@ public class JaudiotaggerParser extends MetaDataParser {
         Integer result = null;
 
         try {
-            result = new Integer(year);
+            result = Integer.valueOf(year);
         } catch (NumberFormatException x) {
             Matcher matcher = YEAR_NUMBER_PATTERN.matcher(year);
             if (matcher.matches()) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/sonos/SonosHelper.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/sonos/SonosHelper.java
@@ -118,9 +118,7 @@ public class SonosHelper {
         List<MediaFile> albums = searchService.getRandomAlbums(40, musicFolders);
         List<MediaFile> songs = new ArrayList<MediaFile>();
         for (MediaFile album : albums) {
-            for (MediaFile file : filterMusic(mediaFileService.getChildrenOf(album, true, false, false))) {
-                songs.add(file);
-            }
+            songs.addAll(filterMusic(mediaFileService.getChildrenOf(album, true, false, false)));
         }
         Collections.shuffle(songs);
         songs = songs.subList(0, Math.min(count, songs.size()));

--- a/airsonic-main/src/main/java/org/airsonic/player/taglib/UrlTag.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/taglib/UrlTag.java
@@ -88,7 +88,7 @@ public class UrlTag extends BodyTagSupport {
     private String formatUrl() throws JspException {
         String baseUrl = UrlSupport.resolveUrl(value, null, pageContext);
 
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         result.append(baseUrl);
         if (!parameters.isEmpty()) {
             result.append('?');

--- a/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
@@ -30,10 +30,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.text.*;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -327,7 +324,7 @@ public final class StringUtil {
      * @return Whether a and b are equal, or both null.
      */
     public static boolean isEqual(Object a, Object b) {
-        return a == null ? b == null : a.equals(b);
+        return Objects.equals(a, b);
     }
 
     /**

--- a/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistServiceTestImport.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistServiceTestImport.java
@@ -88,9 +88,9 @@ public class PlaylistServiceTestImport {
         FileUtils.touch(mf2);
         File mf3 = folder.newFile();
         FileUtils.touch(mf3);
-        builder.append(mf1.getAbsolutePath() + "\n");
-        builder.append(mf2.getAbsolutePath() + "\n");
-        builder.append(mf3.getAbsolutePath() + "\n");
+        builder.append(mf1.getAbsolutePath()).append("\n");
+        builder.append(mf2.getAbsolutePath()).append("\n");
+        builder.append(mf3.getAbsolutePath()).append("\n");
         doAnswer(new PersistPlayList(23)).when(playlistDao).createPlaylist(any());
         doAnswer(new MediaFileHasEverything()).when(mediaFileService).getMediaFile(any(File.class));
         InputStream inputStream = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
@@ -122,9 +122,9 @@ public class PlaylistServiceTestImport {
         FileUtils.touch(mf2);
         File mf3 = folder.newFile();
         FileUtils.touch(mf3);
-        builder.append("File1=" + mf1.getAbsolutePath() + "\n");
-        builder.append("File2=" + mf2.getAbsolutePath() + "\n");
-        builder.append("File3=" + mf3.getAbsolutePath() + "\n");
+        builder.append("File1=").append(mf1.getAbsolutePath()).append("\n");
+        builder.append("File2=").append(mf2.getAbsolutePath()).append("\n");
+        builder.append("File3=").append(mf3.getAbsolutePath()).append("\n");
         doAnswer(new PersistPlayList(23)).when(playlistDao).createPlaylist(any());
         doAnswer(new MediaFileHasEverything()).when(mediaFileService).getMediaFile(any(File.class));
         InputStream inputStream = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
@@ -158,9 +158,9 @@ public class PlaylistServiceTestImport {
         FileUtils.touch(mf2);
         File mf3 = folder.newFile();
         FileUtils.touch(mf3);
-        builder.append("<track><location>file://" + mf1.getAbsolutePath() + "</location></track>\n");
-        builder.append("<track><location>file://" + mf2.getAbsolutePath() + "</location></track>\n");
-        builder.append("<track><location>file://" + mf3.getAbsolutePath() + "</location></track>\n");
+        builder.append("<track><location>file://").append(mf1.getAbsolutePath()).append("</location></track>\n");
+        builder.append("<track><location>file://").append(mf2.getAbsolutePath()).append("</location></track>\n");
+        builder.append("<track><location>file://").append(mf3.getAbsolutePath()).append("</location></track>\n");
         builder.append("    </trackList>\n" + "</playlist>\n");
         doAnswer(new PersistPlayList(23)).when(playlistDao).createPlaylist(any());
         doAnswer(new MediaFileHasEverything()).when(mediaFileService).getMediaFile(any(File.class));


### PR DESCRIPTION
    This is a first batch of simple modernization of the codebase
    
    I threw airsonic at IntelliJ's IDEA analysis,
    and asked it to flag what could be modernized
    for Java > 5.
    
    - foreach instead of for…
    - I added some null-deref checks
    - Integer.ValueOf, since Integer(…) is deprecated
    - Contextual try
    - Objects.equals instead of handcrafted comparisons
    - StringBuilder instead of StringBuffer
    - Removal of outdated/wrong javadoc comments
    - Replace unnecessary getters/setters with inline assignments
    - Simplify string constructions
    - Improve containers construction
