### PR TITLE
Simplify the travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-sudo: required
 jdk:
   - oraclejdk8
 services:
@@ -7,12 +6,5 @@ services:
 cache:
   directories:
     - $HOME/.m2
-install:
-  - sudo apt-get -qq update
-before_script:
-  - wget http://apache.mirrors.tds.net/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
-  - tar -xvf apache-maven-3.5.4-bin.tar.gz
-  - export M2_HOME=$PWD/apache-maven-3.5.4
-  - export PATH=$PWD/apache-maven-3.5.4/bin:$PATH
 script:
   - mvn verify -B -P integration-test


### PR DESCRIPTION
Simplify the travis file
    
- Remove `sudo` since it's deprecated, along with the useless `apt update` call
- Remove the manual maven installation since it's already present on the travis image by default.
    
This should reduce a bit the time taken for a whole CI run, and improve a bit it's maintainability.