### PR TITLE
Fix StringIndexOutOfBounds errors thrown by DWR/YUI

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -232,6 +232,15 @@
             <artifactId>yuicompressor</artifactId>
             <version>2.4.8</version>
             <scope>runtime</scope>
+            <!-- Necessary to avoid StringIndexOutOfBoundsException when running as a JAR -->
+            <!-- See: https://github.com/yui/yuicompressor/issues/161 -->
+            <!-- See also: https://stackoverflow.com/questions/8429095 -->
+            <exclusions>
+              <exclusion>
+                <artifactId>js</artifactId>
+                <groupId>rhino</groupId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This fixes the following errors in DWR caused by updating YUI from 2.3.6 to 2.4.8 in 86e58cea3a2f069e1e1fe1d1860bdc535d41d212:

```
2019-03-28 22:03:10.272  WARN --- o.d.servlet.JavaScriptHandler            : Compression system (YahooJSCompressor) failed to compress script
java.lang.StringIndexOutOfBoundsException: begin 919, end 1000, length 920
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3107) ~[na:na]
        at java.base/java.lang.String.substring(String.java:1873) ~[na:na]
        ...
```

See more info in https://github.com/yui/yuicompressor/issues/161.

Tested on both self-contained JAR and Tomcat 8.