### PR TITLE
Remove inline javascript on the `cancel` buttons

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/advancedSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/advancedSettings.jsp
@@ -168,7 +168,7 @@
     <p class="warning"><fmt:message key="advancedsettings.ldapRequiresRestart"/></p>
 
     <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-    <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+    <a href="nowPlaying.view"><input type="button" value="<fmt:message key="common.cancel"/>"></a>
 
 </form:form>
 

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/databaseSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/databaseSettings.jsp
@@ -119,7 +119,7 @@
 
     <p>
         <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-        <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+        <a href="nowPlaying.view"><input type="button" value="<fmt:message key="common.cancel"/>"></a>
     </p>
 
 </form:form>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/dlnaSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/dlnaSettings.jsp
@@ -65,7 +65,7 @@
 
     <p>
         <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-        <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+        <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>"></a>
     </p>
 
 </form>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/generalSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/generalSettings.jsp
@@ -158,7 +158,7 @@
         <tr>
             <td colspan="2" style="padding-top:1.5em">
                 <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-                <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+                <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>"></a>
             </td>
         </tr>
 

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/internetRadioSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/internetRadioSettings.jsp
@@ -49,7 +49,7 @@
     <tr>
         <td style="padding-top:1.5em" colspan="5">
             <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-            <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+            <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>"></a>
         </td>
     </tr>
 </table>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/musicFolderSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/musicFolderSettings.jsp
@@ -139,7 +139,7 @@
 
     <p >
         <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-        <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+        <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>"></a>
     </p>
 
 </form:form>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/passwordSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/passwordSettings.jsp
@@ -38,7 +38,7 @@
                 <tr>
                     <td colspan="3" style="padding-top:1.5em">
                         <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-                        <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+                        <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>"></a>
                     </td>
                 </tr>
 

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
@@ -208,7 +208,7 @@
 
     <p style="padding-top:1em;padding-bottom:1em">
         <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em"/>
-        <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+        <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>"></a>
     </p>
 
     <h2><fmt:message key="personalsettings.avatar.title"/></h2>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playerSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playerSettings.jsp
@@ -196,7 +196,7 @@ $(document).ready(function() {
             </c:if>
 
             <input type="submit" value="<fmt:message key="common.save"/>" style="margin-top:1em;margin-right:0.3em">
-            <input type="button" value="<fmt:message key="common.cancel"/>" style="margin-top:1em" onclick="location.href='nowPlaying.view'">
+            <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>" style="margin-top:1em"></a>
         </form:form>
     </c:otherwise>
 </c:choose>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/podcastSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/podcastSettings.jsp
@@ -80,7 +80,7 @@
     <tr>
         <td style="padding-top:1.5em" colspan="2">
             <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-            <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+            <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>"></a>
         </td>
     </tr>
 

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/shareSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/shareSettings.jsp
@@ -58,7 +58,7 @@
 
     <p style="padding-top:1em">
         <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-        <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'" style="margin-right:2.0em">
+        <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>" style="margin-right:2.0em"></a>
         <input type="checkbox" id="deleteExpired" name="deleteExpired" class="checkbox"/>
         <label for="deleteExpired"><fmt:message key="sharesettings.deleteexpired"/></label>
     </p>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/sonosSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/sonosSettings.jsp
@@ -56,7 +56,7 @@
 
     <p>
         <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-        <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'">
+        <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>"></a>
     </p>
 
 </form>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
@@ -87,7 +87,7 @@
 
     <p style="padding-top:0.75em">
         <input type="submit" value="<fmt:message key="common.save"/>" style="margin-right:0.3em">
-        <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'" style="margin-right:1.3em">
+        <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>" style="margin-right:1.3em"></a>
         <a href="https://airsonic.github.io/docs/transcode/" target="_blank"><fmt:message key="transcodingsettings.recommended"/></a>
     </p>
 

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/userSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/userSettings.jsp
@@ -215,7 +215,7 @@
     </c:choose>
 
     <input type="submit" value="<fmt:message key="common.save"/>" style="margin-top:1.5em;margin-right:0.3em">
-    <input type="button" value="<fmt:message key="common.cancel"/>" onclick="location.href='nowPlaying.view'" style="margin-top:1.5em">
+    <a href='nowPlaying.view'><input type="button" value="<fmt:message key="common.cancel"/>" style="margin-top:1.5em"></a>
 </form:form>
 
 </body></html>

--- a/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
+++ b/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
@@ -205,6 +205,11 @@ input[type=submit], input[type=button] {
     background: white;
     padding-left: 1em;
     padding-right: 1em;
+    color: black;
+}
+
+input[type=submit]:hover, input[type=button]:hover {
+    text-decoration: none;
 }
 
 input[type=submit]:active, input[type=button]:active {


### PR DESCRIPTION
The inline javascript used with the cancel buttons
was only used to change the location.
Instead of doing this, it's easier to wrap
the button in a <a> tag.

This is related to #909.