### PR TITLE
Add two <meta> tags

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/head.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/head.jsp
@@ -9,6 +9,8 @@
 <link rel="mask-icon" href="<c:url value="/icons/safari-pinned-tab.svg"/>" color="#2f7bd9"/>
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="theme-color" content="#ffffff">
+<meta name="description" content="Airsonic: A free, web-based media streamer, providing ubiquitous access to your music.">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <!-- Included before airsonic stylesheet to allow overriding -->
 <link type="text/css" rel="stylesheet" href="<c:url value="/script/mediaelement/mediaelementplayer.min.css"/>">
 <link rel="stylesheet" href="<c:url value="/${styleSheet}"/>" type="text/css">


### PR DESCRIPTION
- Add a description, since this can be useful
  in browser's histories
- Add a viewport, making it less worse to use
  airsonic on a super-small screen
