### PR TITLE
Use a random key to "encrypt" the remember-me cookie's value

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -33,14 +33,6 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
 
     static final String FAILURE_URL = "/login?error=1";
 
-    private static final String key;
-
-    static {
-      byte[] array = new byte[32];
-      new SecureRandom().nextBytes(array);
-      key = new String(array);
-    }
-
     @Autowired
     private SecurityService securityService;
 
@@ -79,6 +71,11 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
         auth.authenticationProvider(new JWTAuthenticationProvider(jwtKey));
     }
 
+    private static String generateRememberMeKey() {
+      byte[] array = new byte[32];
+      new SecureRandom().nextBytes(array);
+      return new String(array);
+    }
 
     @Configuration
     @Order(1)
@@ -172,7 +169,7 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
                     // see http://docs.spring.io/spring-security/site/docs/3.2.4.RELEASE/reference/htmlsingle/#csrf-logout
                     .and().logout().logoutRequestMatcher(new AntPathRequestMatcher("/logout", "GET")).logoutSuccessUrl(
                     "/login?logout")
-                    .and().rememberMe().key(key);
+                    .and().rememberMe().key(generateRememberMeKey());
         }
 
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -22,6 +22,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
+import java.security.SecureRandom;
+
 @Configuration
 @Order(SecurityProperties.ACCESS_OVERRIDE_ORDER)
 @EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
@@ -30,6 +32,14 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
     private static Logger logger = LoggerFactory.getLogger(GlobalSecurityConfig.class);
 
     static final String FAILURE_URL = "/login?error=1";
+
+    private static final String key;
+
+    static {
+      byte[] array = new byte[32];
+      new SecureRandom().nextBytes(array);
+      key = new String(array);
+    }
 
     @Autowired
     private SecurityService securityService;
@@ -162,7 +172,7 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
                     // see http://docs.spring.io/spring-security/site/docs/3.2.4.RELEASE/reference/htmlsingle/#csrf-logout
                     .and().logout().logoutRequestMatcher(new AntPathRequestMatcher("/logout", "GET")).logoutSuccessUrl(
                     "/login?logout")
-                    .and().rememberMe().key("airsonic");
+                    .and().rememberMe().key(key);
         }
 
     }


### PR DESCRIPTION
Since Spring's default remember-me technique is
terrible security-wise (`user:timstamp:md5(use:timestamp:password:key)`),
we should at least use a random key, instead of a fixed one,
otherwise, and attacker able to capture the cookies
might be able to trivially bruteforce offline
the password of the associated user.

My Java-fu is pretty weak, so feel free to tell me if there is a more idiomatic way of doing this.