### PR TITLE
Replace the deprecated CloseQuietly method calls

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -26,7 +26,6 @@ import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.HttpRange;
 import org.airsonic.player.util.Util;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -262,9 +261,8 @@ public class DownloadController implements LastModified {
         LOG.info("Downloading '" + FileUtil.getShortPath(file) + "' to " + status.getPlayer());
 
         final int bufferSize = 16 * 1024; // 16 Kbit
-        InputStream in = new BufferedInputStream(new FileInputStream(file), bufferSize);
 
-        try {
+        try ( InputStream in = new BufferedInputStream(new FileInputStream(file), bufferSize)){
             byte[] buf = new byte[bufferSize];
             long bitrateLimit = 0;
             long lastLimitCheck = 0;
@@ -307,7 +305,6 @@ public class DownloadController implements LastModified {
             }
         } finally {
             out.flush();
-            IOUtils.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
@@ -20,7 +20,6 @@
 package org.airsonic.player.controller;
 
 import org.airsonic.player.util.StringUtil;
-import org.apache.commons.io.IOUtils;
 import org.eclipse.persistence.jaxb.JAXBContext;
 import org.eclipse.persistence.jaxb.MarshallerProperties;
 import org.jdom2.Attribute;
@@ -97,14 +96,10 @@ public class JAXBWriter {
     }
 
     private String getRESTProtocolVersion() throws Exception {
-        InputStream in = null;
-        try {
-            in = StringUtil.class.getResourceAsStream("/subsonic-rest-api.xsd");
+        try (InputStream in = StringUtil.class.getResourceAsStream("/subsonic-rest-api.xsd")) {
             Document document = createSAXBuilder().build(in);
             Attribute version = document.getRootElement().getAttribute("version");
             return version.getValue();
-        } finally {
-            IOUtils.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/ProxyController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/ProxyController.java
@@ -19,6 +19,8 @@
  */
 package org.airsonic.player.controller;
 
+import org.airsonic.player.util.FileUtil;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -70,7 +72,7 @@ public class ProxyController  {
                 }
             }
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
         return null;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -26,10 +26,10 @@ import org.airsonic.player.io.ShoutCastOutputStream;
 import org.airsonic.player.security.JWTAuthenticationToken;
 import org.airsonic.player.service.*;
 import org.airsonic.player.service.sonos.SonosHelper;
+import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.HttpRange;
 import org.airsonic.player.util.StringUtil;
 import org.airsonic.player.util.Util;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -278,7 +278,7 @@ public class StreamController {
                 securityService.updateUserByteCounts(user, status.getBytesTransfered(), 0L, 0L);
                 statusService.removeStreamStatus(status);
             }
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
         return;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -1138,9 +1138,9 @@ public class SubsonicRESTController {
         } else if ("newest".equals(type)) {
             albums = albumDao.getNewestAlbums(offset, size, musicFolders);
         } else if ("alphabeticalByArtist".equals(type)) {
-            albums = albumDao.getAlphabetialAlbums(offset, size, true, musicFolders);
+            albums = albumDao.getAlphabeticalAlbums(offset, size, true, true, musicFolders);
         } else if ("alphabeticalByName".equals(type)) {
-            albums = albumDao.getAlphabetialAlbums(offset, size, false, musicFolders);
+            albums = albumDao.getAlphabeticalAlbums(offset, size, false, true, musicFolders);
         } else if ("byGenre".equals(type)) {
             albums = albumDao.getAlbumsByGenre(offset, size, getRequiredStringParameter(request, "genre"), musicFolders);
         } else if ("byYear".equals(type)) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
@@ -31,7 +31,6 @@ import org.airsonic.player.util.StringUtil;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -184,26 +183,19 @@ public class UploadController {
                     }
 
                     entryFile.getParentFile().mkdirs();
-                    InputStream inputStream = null;
-                    OutputStream outputStream = null;
-                    try {
-                        inputStream = zipFile.getInputStream(entry);
-                        outputStream = new FileOutputStream(entryFile);
-
-                        byte[] buf = new byte[8192];
-                        while (true) {
-                            int n = inputStream.read(buf);
-                            if (n == -1) {
-                                break;
+                    try (InputStream inputStream = zipFile.getInputStream(entry)){
+                        try (OutputStream outputStream = new FileOutputStream(entryFile)) {
+                            byte[] buf = new byte[8192];
+                            while (true) {
+                                int n = inputStream.read(buf);
+                                if (n == -1) {
+                                    break;
+                                }
+                                outputStream.write(buf, 0, n);
                             }
-                            outputStream.write(buf, 0, n);
                         }
-
                         LOG.info("Unzipped " + entryFile);
                         unzippedFiles.add(entryFile);
-                    } finally {
-                        IOUtils.closeQuietly(inputStream);
-                        IOUtils.closeQuietly(outputStream);
                     }
                 }
             }

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
@@ -154,20 +154,6 @@ public class AlbumDao extends AbstractDao {
      * @param count        Maximum number of albums to return.
      * @param byArtist     Whether to sort by artist name
      * @param musicFolders Only return albums from these folders.
-     * @return Albums in alphabetical order.
-     */
-    @Deprecated
-    public List<Album> getAlphabetialAlbums(final int offset, final int count, boolean byArtist, final List<MusicFolder> musicFolders) {
-        return getAlphabeticalAlbums(offset, count, byArtist, false, musicFolders);
-    }
-
-    /**
-     * Returns albums in alphabetical order.
-     *
-     * @param offset       Number of albums to skip.
-     * @param count        Maximum number of albums to return.
-     * @param byArtist     Whether to sort by artist name
-     * @param musicFolders Only return albums from these folders.
      * @param ignoreCase   Use case insensitive sorting
      * @return Albums in alphabetical order.
      */

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MusicFolder.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MusicFolder.java
@@ -34,6 +34,7 @@ import java.util.List;
  * @author Sindre Mehus
  * @version $Revision: 1.1 $ $Date: 2005/11/27 14:32:05 $
  */
+@SuppressWarnings("serial")
 public class MusicFolder implements Serializable {
 
     private Integer id;

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MusicIndex.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MusicIndex.java
@@ -39,6 +39,7 @@ import java.util.Objects;
  *
  * @author Sindre Mehus
  */
+@SuppressWarnings("serial")
 public class MusicIndex implements Serializable {
 
     public static final MusicIndex OTHER = new MusicIndex("#");

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
@@ -289,6 +289,7 @@ public class TransferStatus {
     /**
      * Contains recent history of samples.
      */
+    @SuppressWarnings("serial")
     public static class SampleHistory extends BoundedList<Sample> {
 
         public SampleHistory() {

--- a/airsonic-main/src/main/java/org/airsonic/player/io/InputStreamReaderThread.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/InputStreamReaderThread.java
@@ -19,7 +19,8 @@
  */
 package org.airsonic.player.io;
 
-import org.apache.commons.io.IOUtils;
+import org.airsonic.player.util.FileUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,9 +51,7 @@ public class InputStreamReaderThread extends Thread {
     }
 
     public void run() {
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new InputStreamReader(input));
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))){
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {
                 if (log) {
                     LOG.info('(' + name + ") " + line);
@@ -61,8 +60,7 @@ public class InputStreamReaderThread extends Thread {
         } catch (IOException x) {
             // Intentionally ignored.
         } finally {
-            IOUtils.closeQuietly(reader);
-            IOUtils.closeQuietly(input);
+            FileUtil.closeQuietly(input);
         }
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/io/TranscodeInputStream.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/TranscodeInputStream.java
@@ -19,6 +19,8 @@
  */
 package org.airsonic.player.io;
 
+import org.airsonic.player.util.FileUtil;
+
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,8 +81,8 @@ public class TranscodeInputStream extends InputStream {
                     } catch (IOException x) {
                         // Intentionally ignored. Will happen if the remote player closes the stream.
                     } finally {
-                        IOUtils.closeQuietly(in);
-                        IOUtils.closeQuietly(processOutputStream);
+                        FileUtil.closeQuietly(in);
+                        FileUtil.closeQuietly(processOutputStream);
                     }
                 }
             }.start();
@@ -112,8 +114,16 @@ public class TranscodeInputStream extends InputStream {
      * @see InputStream#close()
      */
     public void close() throws IOException {
-        IOUtils.closeQuietly(processInputStream);
-        IOUtils.closeQuietly(processOutputStream);
+        try {
+            processInputStream.close();
+        } catch (Exception x) {
+            LOG.error("Error while closing the process input stream: " + x, x);
+        }
+        try {
+            processOutputStream.close();
+        } catch (Exception x) {
+            LOG.error("Error while closing the process output stream: " + x, x);
+        }
 
         if (process != null) {
             process.destroy();

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MusicIndexService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MusicIndexService.java
@@ -246,6 +246,7 @@ public class MusicIndexService {
         this.mediaFileService = mediaFileService;
     }
 
+		@SuppressWarnings("serial")
     private static class MusicIndexComparator implements Comparator<MusicIndex>, Serializable {
 
         private List<MusicIndex> indexes;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistService.java
@@ -33,7 +33,6 @@ import org.airsonic.player.service.playlist.PlaylistImportHandler;
 import org.airsonic.player.util.Pair;
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,12 +76,12 @@ public class PlaylistService {
             List<PlaylistExportHandler> exportHandlers,
             List<PlaylistImportHandler> importHandlers
     ) {
-        Assert.notNull(mediaFileDao);
-        Assert.notNull(playlistDao);
-        Assert.notNull(securityService);
-        Assert.notNull(settingsService);
-        Assert.notNull(exportHandlers);
-        Assert.notNull(importHandlers);
+        Assert.notNull(mediaFileDao, "mediaFileDao is null");
+        Assert.notNull(playlistDao, "playlistDao is null");
+        Assert.notNull(securityService, "securityService is null");
+        Assert.notNull(settingsService, "settingsService is null");
+        Assert.notNull(exportHandlers, "exportHandlers is null");
+        Assert.notNull(importHandlers, "importHandlers is null");
         this.mediaFileDao = mediaFileDao;
         this.playlistDao = playlistDao;
         this.securityService = securityService;
@@ -294,12 +293,9 @@ public class PlaylistService {
                 }
             }
         }
-        InputStream in = new FileInputStream(file);
-        try {
+        try ( InputStream in = new FileInputStream(file)) {
             importPlaylist(User.USERNAME_ADMIN, FilenameUtils.getBaseName(fileName), fileName, in, existingPlaylist);
             LOG.info("Auto-imported playlist " + file);
-        } finally {
-            IOUtils.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/UPnPService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/UPnPService.java
@@ -22,7 +22,6 @@ package org.airsonic.player.service;
 import org.airsonic.player.service.upnp.ApacheUpnpServiceConfiguration;
 import org.airsonic.player.service.upnp.CustomContentDirectory;
 import org.airsonic.player.service.upnp.MSMediaReceiverRegistrarService;
-import org.apache.commons.io.IOUtils;
 import org.fourthline.cling.UpnpService;
 import org.fourthline.cling.UpnpServiceImpl;
 import org.fourthline.cling.binding.annotations.AnnotationLocalServiceBinder;
@@ -157,9 +156,10 @@ public class UPnPService {
                 new ModelDetails(serverName),
                 new DLNADoc[]{new DLNADoc("DMS", DLNADoc.Version.V1_5)}, null);
 
-        InputStream in = getClass().getResourceAsStream("logo-512.png");
-        Icon icon = new Icon("image/png", 512, 512, 32, "logo-512", in);
-        IOUtils.closeQuietly(in);
+        Icon icon = null;
+        try (InputStream in = getClass().getResourceAsStream("logo-512.png")) {
+          icon = new Icon("image/png", 512, 512, 32, "logo-512", in);
+        }
 
         LocalService<CustomContentDirectory> contentDirectoryservice = new AnnotationLocalServiceBinder().read(CustomContentDirectory.class);
         contentDirectoryservice.setManager(new DefaultServiceManager<CustomContentDirectory>(contentDirectoryservice) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
@@ -21,7 +21,6 @@ package org.airsonic.player.service;
 
 import com.jayway.jsonpath.JsonPath;
 import org.airsonic.player.domain.Version;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
@@ -188,21 +187,17 @@ public class VersionService {
      * @return The first line of the resource.
      */
     private String readLineFromResource(String resourceName) {
-        InputStream in = VersionService.class.getResourceAsStream(resourceName);
-        if (in == null) {
+        try(InputStream in = VersionService.class.getResourceAsStream(resourceName)) {
+            if (in == null) {
+                return null;
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))){
+                return reader.readLine();
+            } catch (IOException x) {
+                return null;
+            }
+        } catch (Exception x) {
             return null;
-        }
-        BufferedReader reader = null;
-        try {
-
-            reader = new BufferedReader(new InputStreamReader(in));
-            return reader.readLine();
-
-        } catch (IOException x) {
-            return null;
-        } finally {
-            IOUtils.closeQuietly(reader);
-            IOUtils.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/jukebox/AudioPlayer.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/jukebox/AudioPlayer.java
@@ -19,7 +19,8 @@
  */
 package org.airsonic.player.service.jukebox;
 
-import org.apache.commons.io.IOUtils;
+import org.airsonic.player.util.FileUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,7 +115,7 @@ public class AudioPlayer {
         } catch (Throwable x) {
             LOG.warn("Failed to close player: " + x, x);
         }
-        IOUtils.closeQuietly(in);
+				FileUtil.closeQuietly(in);
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/util/BoundedList.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/BoundedList.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
  * @author Sindre Mehus
  * @version $Revision: 1.1 $ $Date: 2005/05/09 20:01:25 $
  */
+@SuppressWarnings("serial")
 public class BoundedList<E> extends LinkedList<E> {
     private int maxSize;
 

--- a/airsonic-main/src/main/java/org/airsonic/player/util/Pair.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/Pair.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 /**
  * @author Sindre Mehus
  */
+@SuppressWarnings("serial")
 public class Pair<S, T> implements Serializable {
 
     private final S first;

--- a/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
@@ -20,7 +20,6 @@
 package org.airsonic.player.util;
 
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.*;
@@ -278,10 +277,7 @@ public final class StringUtil {
      * @throws IOException If an I/O error occurs.
      */
     public static String[] readLines(InputStream in) throws IOException {
-        BufferedReader reader = null;
-
-        try {
-            reader = new BufferedReader(new InputStreamReader(in));
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
             List<String> result = new ArrayList<String>();
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {
                 line = line.trim();
@@ -290,11 +286,9 @@ public final class StringUtil {
                 }
             }
             return result.toArray(new String[result.size()]);
-
         } finally {
-            IOUtils.closeQuietly(in);
-            IOUtils.closeQuietly(reader);
-        }
+            FileUtil.closeQuietly(in);
+				}
     }
 
     /**

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -25,7 +25,7 @@
 
             <input required type="password" autocomplete="off"  name="j_password" tabindex="2" placeholder="<fmt:message key="login.password"/>">
 
-            <input name="submit" type="submit" value="<fmt:message key="login.login"/>" tabindex="4"></td>
+            <input name="submit" type="submit" value="<fmt:message key="login.login"/>" tabindex="4">
 
             <div class="details">
                 <div id="loginremember">

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
+                    <configuration>
+                      <compilerArgs>
+                        <arg>-Xlint:all,-options,-path</arg>
+                      </compilerArgs>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This (massive) PR fixes some deprecation and simple stuff spotted by `-Xlint` (now enabled by default) and [IntelliJ's IDEA]( https://www.jetbrains.com/idea/ )'s analysis.