### PR TITLE
[WIP] Bump the version of dependency-check-maven

### DIFF
--- a/airsonic-main/cve-suppressed.xml
+++ b/airsonic-main/cve-suppressed.xml
@@ -164,6 +164,16 @@
        <cve>CVE-2018-1258</cve>
     </suppress>
     <suppress>
+       <notes>False positive for jflac-codec</notes>
+       <gav regex="true">.*jflac-codec.*</gav>
+       <cve>CVE-2018-14948</cve>
+    </suppress>
+    <suppress>
+       <notes>False positive for java-jwt</notes>
+       <gav regex="true">.*java-jwt.*</gav>
+       <cve>CVE-2017-17068</cve>
+    </suppress>
+    <suppress>
         <notes>This is for an unrelated C library</notes>
         <gav regex="true">^com\.sun\.xml\.bind\.external:relaxng-datatype:.*</gav>
         <cve>CVE-2018-18749</cve>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>4.0.0</version>
+                    <version>5.0.0-M2</version>
                     <inherited>true</inherited>
                     <configuration>
                         <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>5.0.0-M2</version>
+                    <version>5.0.0-M3</version>
                     <inherited>true</inherited>
                     <configuration>
                         <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>


### PR DESCRIPTION
Updating dependency-check-maven has the nice side-effect of improving its detection capacities, yielding a few vulnerabilities that we should fix before merging this PR:

- [ ] Jquery and JqueryUI (#930)
- [ ] Liquibase-core
- [ ] spring-*
- [ ] posgresql
- [ ] apache-jsp