### PR TITLE
Fix a NULL-deref in CoverArtController.java

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -381,7 +381,10 @@ public class CoverArtController implements LastModified {
                 InputStream in = null;
                 try {
                     in = getImageInputStream(coverArt);
-                    return scale(ImageIO.read(in), size, size);
+                    BufferedImage bimg = ImageIO.read(in);
+                    if (bimg != null) {
+                      return scale(bimg, size, size);
+                    }
                 } catch (Throwable x) {
                     LOG.warn("Failed to process cover art " + coverArt + ": " + x, x);
                 } finally {


### PR DESCRIPTION
ImageIO.read() can (and will) return null in certain cases.