### PR TITLE
Don't autocomplete the password field

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -23,7 +23,7 @@
 
             <input type="text" autofocus id="j_username" name="j_username" tabindex="1" placeholder="<fmt:message key="login.username"/>">
 
-            <input type="password" name="j_password" tabindex="2" placeholder="<fmt:message key="login.password"/>">
+            <input type="password" autocomplete="off" name="j_password" tabindex="2" placeholder="<fmt:message key="login.password"/>">
 
             <input name="submit" type="submit" value="<fmt:message key="login.login"/>" tabindex="4"></td>
 


### PR DESCRIPTION
I guess that this is a bit silly in 2019,
but since people tend to use weird browsers in weird
places, disabling autocompletion here might prevent
the password from ending up in some local cache.