### PR TITLE
Clicking on the logo now redirects to home instead of about

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/left.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/left.jsp
@@ -59,7 +59,9 @@
 <a name="top"></a>
 
 <div style="padding-bottom:1.5em">
-    <a href="help.view?" target="main"><img src="<spring:theme code="logoImage"/>" style="width:196px" title="<fmt:message key="top.help"/>" alt=""></a>
+    <a href="home.view" target="main">
+      <img src="<spring:theme code="logoImage"/>" style="width:196px" title="<fmt:message key="top.help"/>" alt="">
+    </a>
 </div>
 
 <c:if test="${fn:length(model.musicFolders) > 1}">


### PR DESCRIPTION
The previous behaviour was confusing, because on
most websites, clicking on the logo will redirect
to the main page, and not on the about one.