### PR TITLE
Move some cast-related inline js to an external file

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -10,7 +10,7 @@
     <script type="text/javascript" src="<c:url value="/dwr/engine.js"/>"></script>
     <script type="text/javascript" src="<c:url value="/dwr/util.js"/>"></script>
     <script type="text/javascript" src="<c:url value="/script/mediaelement/mediaelement-and-player.min.js"/>"></script>
-    <%@ include file="playQueueCast.jsp" %>
+    <script type="text/javascript" src="<c:url value="/script/playQueueCast.js"/>"></script>
     <style type="text/css">
         .ui-slider .ui-slider-handle {
             width: 11px;

--- a/airsonic-main/src/main/webapp/script/playQueueCast.js
+++ b/airsonic-main/src/main/webapp/script/playQueueCast.js
@@ -1,4 +1,3 @@
-<script type="text/javascript">
 (function () {
     'use strict';
 
@@ -274,5 +273,3 @@
 
     window.CastPlayer = CastPlayer;
 })();
-
-</script>


### PR DESCRIPTION
There is no point in having such a massive blob of javascript inline in the page.