### PR TITLE
Compatible with ID3 v2.4

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -97,8 +97,8 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setTrackNumber(parseTrackNumber(getTagField(tag, FieldKey.TRACK)));
                 metaData.setMusicBrainzReleaseId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEID));
 
-                String songArtist = getTagField(tag, FieldKey.ARTIST);
-                String albumArtist = getTagField(tag, FieldKey.ALBUM_ARTIST);
+                metaData.setArtist(getTagField(tag, FieldKey.ARTIST));
+                metaData.setAlbumArtist(getTagField(tag, FieldKey.ALBUM_ARTIST));
 
                 if (tag instanceof AbstractID3Tag && 0 < audioFile.getTag().getFieldCount()) {
 
@@ -140,7 +140,7 @@ public class JaudiotaggerParser extends MetaDataParser {
                                     }
                                     break;
                                 case ID3v24Frames.FRAME_ID_ARTIST:
-                                    if (null == metaData.getArtist() && null == songArtist) {
+                                    if (null == metaData.getArtist()) {
                                         metaData.setArtist(f.toString());
                                     }
                                     break;
@@ -155,11 +155,11 @@ public class JaudiotaggerParser extends MetaDataParser {
                         });
                     }
                 }
-                if(StringUtils.isBlank(metaData.getArtist())) {
-                    metaData.setArtist(StringUtils.isBlank(songArtist) ? albumArtist : songArtist);
+                if (StringUtils.isBlank(metaData.getArtist())) {
+                    metaData.setArtist(metaData.getAlbumArtist());
                 }
-                if(StringUtils.isBlank(metaData.getAlbumArtist())) {
-                    metaData.setAlbumArtist(StringUtils.isBlank(albumArtist) ? songArtist : albumArtist);
+                if (StringUtils.isBlank(metaData.getAlbumArtist())) {
+                    metaData.setAlbumArtist(metaData.getArtist());
                 }
 
             }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
 
 import java.io.File;
 import java.util.SortedSet;
@@ -110,42 +111,42 @@ public class JaudiotaggerParser extends MetaDataParser {
                         audioFile.getTag().getFields().forEachRemaining(f -> {
                             switch (f.getId()) {
                                 case ID3v24Frames.FRAME_ID_ALBUM:
-                                    if (null == metaData.getAlbumName()) {
+                                    if (StringUtils.isBlank(metaData.getAlbumName())) {
                                         metaData.setAlbumName(f.toString());
                                     }
                                     break;
                                 case ID3v24Frames.FRAME_ID_TITLE:
-                                    if (null == metaData.getTitle()) {
+                                    if (StringUtils.isBlank(metaData.getTitle())) {
                                         metaData.setTitle(f.toString());
                                     }
                                     break;
                                 case ID3v24Frames.FRAME_ID_YEAR:
-                                    if (null == metaData.getYear()) {
+                                    if (ObjectUtils.isEmpty(metaData.getYear())) {
                                         metaData.setYear(parseYear(f.toString()));
                                     }
                                     break;
                                 case ID3v24Frames.FRAME_ID_GENRE:
-                                    if (null == metaData.getGenre()) {
+                                    if (StringUtils.isBlank(metaData.getGenre())) {
                                         metaData.setGenre(mapGenre(f.toString()));
                                     }
                                     break;
                                 case ID3v24Frames.FRAME_ID_SET:
-                                    if (null == metaData.getDiscNumber()) {
+                                    if (ObjectUtils.isEmpty(metaData.getDiscNumber())) {
                                         metaData.setDiscNumber(parseInteger(f.toString()));
                                     }
                                     break;
                                 case ID3v24Frames.FRAME_ID_TRACK:
-                                    if (null == metaData.getTrackNumber()) {
+                                    if (ObjectUtils.isEmpty(metaData.getTrackNumber())) {
                                         metaData.setTrackNumber(parseTrackNumber(f.toString()));
                                     }
                                     break;
                                 case ID3v24Frames.FRAME_ID_ARTIST:
-                                    if (null == metaData.getArtist()) {
+                                    if (StringUtils.isBlank(metaData.getArtist())) {
                                         metaData.setArtist(f.toString());
                                     }
                                     break;
                                 case ID3v24Frames.FRAME_ID_ACCOMPANIMENT:
-                                    if (null == metaData.getAlbumArtist()) {
+                                    if (StringUtils.isBlank(metaData.getAlbumArtist())) {
                                         metaData.setAlbumArtist(f.toString());
                                     }
                                     break;


### PR DESCRIPTION
(PR #996 again because the commit history gets dirty)

Most recent media files have tags written in ID3 v2.4 format.
The situation where it can not be read by the present tag analysis came to come out.

v2.4 has different continuation and write field.
http://id3.org/id3v2.4.0-frames

In v2.4 media data, the previous field data is empty.
If it is v2.4 form, it works well in the form read additionally.
(The additional processing type may be preferable to handle various formats from ID3v1 to ID3v24 transients.)
___

#### Version check
The processing added in this PR is executed additionally only for the ID3v24 file.

#### ifnull check
The processing added to this PR will not be overwritten with the value acquired from the ID3v24 field if the tag value of ID3v24 or earlier has already been read.

Avoiding dirty data done at # 996.
It may be considered as a poor implementation of jaudiotagger, but it may also occur if the format is hybrid to multiple ID3 specifications.


The data in the repository contains data applicable to this case.

![image](https://user-images.githubusercontent.com/27724847/55807897-fc80f600-5b1d-11e9-86b3-fe0318a2389a.png)

![image](https://user-images.githubusercontent.com/27724847/55808340-dd369880-5b1e-11e9-8ff6-837e721ebe42.png)

![image](https://user-images.githubusercontent.com/27724847/55808215-9f397480-5b1e-11e9-96f6-00a0a122b854.png)

Improvement as below by ifnull.

![image](https://user-images.githubusercontent.com/27724847/55829195-1683fe00-5b49-11e9-86b0-5030049cced8.png)

![image](https://user-images.githubusercontent.com/27724847/55829268-3e736180-5b49-11e9-8a70-42578e93dae9.png)

It does not seem to affect the tag edit screen.

![image](https://user-images.githubusercontent.com/27724847/55829305-53e88b80-5b49-11e9-844d-5d3285b73188.png)