### PR TITLE
CVE-2019-3795

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -547,7 +547,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>1.5.8.RELEASE</version>
+                <version>1.5.20.RELEASE</version>
                 <configuration>
                     <mainClass>org.airsonic.player.Application</mainClass>
                     <layout>WAR</layout>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>1.5.18.RELEASE</version>
+                <version>1.5.20.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -132,6 +132,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>27.1-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jdt</groupId>
+                <artifactId>ecj</artifactId>
+                <version>3.14.0</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fix to avoid compilation problems currently occurring with snapshots.

There are two ways.
Both have been verified to be able to launch Tomcat/Jetty standalone.

#### upgrade spring-security-*
A method that adds all spring-security-* (except tests) to POM.
Specify 4.2.12-RELEASE.
Change risk is minimal, and POM is long.

#### upgrade dependencies(This PR)

The latest updates for spring-boot-dependencies and spring-boot-maven-plugin.
However, the version of ecj used to assist compilation is slightly different between jetty and tomcat.
By matching tomcat's ecj version against Jetty, can achieve both.


