### PR TITLE
Add a missing taglib to homePager.jsp

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/homePager.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/homePager.jsp
@@ -1,4 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <table>
     <tr>
         <c:if test="${not empty model.musicFolder}">


### PR DESCRIPTION
The missing taglib is confusing coverity a bit,
and I think that it's a good practise to add it
anyway.
