### PR TITLE
Fix a stacktrace in AvatarController

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/AvatarController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/AvatarController.java
@@ -72,11 +72,11 @@ public class AvatarController implements LastModified {
     }
 
     private Avatar getAvatar(HttpServletRequest request) {
-        String id = request.getParameter("id");
+        Integer id = ServletRequestUtils.getIntParameter(request, "id", null);
         boolean forceCustom = ServletRequestUtils.getBooleanParameter(request, "forceCustom", false);
 
         if (id != null) {
-            return settingsService.getSystemAvatar(Integer.parseInt(id));
+            return settingsService.getSystemAvatar(id);
         }
 
         String username = request.getParameter("username");

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -103,7 +103,7 @@ public class CoverArtController implements LastModified {
 
         CoverArtRequest coverArtRequest = createCoverArtRequest(request);
         LOG.trace("handleRequest - " + coverArtRequest);
-        Integer size = ServletRequestUtils.getIntParameter(request, "size");
+        Integer size = ServletRequestUtils.getIntParameter(request, "size", null);
 
         // Send fallback image if no ID is given. (No need to cache it, since it will be cached in browser.)
         if (coverArtRequest == null) {
@@ -138,19 +138,23 @@ public class CoverArtController implements LastModified {
             return null;
         }
 
-        if (id.startsWith(ALBUM_COVERART_PREFIX)) {
+        try {
+          if (id.startsWith(ALBUM_COVERART_PREFIX)) {
             return createAlbumCoverArtRequest(Integer.valueOf(id.replace(ALBUM_COVERART_PREFIX, "")));
-        }
-        if (id.startsWith(ARTIST_COVERART_PREFIX)) {
+          }
+          if (id.startsWith(ARTIST_COVERART_PREFIX)) {
             return createArtistCoverArtRequest(Integer.valueOf(id.replace(ARTIST_COVERART_PREFIX, "")));
-        }
-        if (id.startsWith(PLAYLIST_COVERART_PREFIX)) {
+          }
+          if (id.startsWith(PLAYLIST_COVERART_PREFIX)) {
             return createPlaylistCoverArtRequest(Integer.valueOf(id.replace(PLAYLIST_COVERART_PREFIX, "")));
-        }
-        if (id.startsWith(PODCAST_COVERART_PREFIX)) {
+          }
+          if (id.startsWith(PODCAST_COVERART_PREFIX)) {
             return createPodcastCoverArtRequest(Integer.valueOf(id.replace(PODCAST_COVERART_PREFIX, "")), request);
+          }
+          return createMediaFileCoverArtRequest(Integer.valueOf(id), request);
+        } catch (NumberFormatException ) {
+          return null;
         }
-        return createMediaFileCoverArtRequest(Integer.valueOf(id), request);
     }
 
     private CoverArtRequest createAlbumCoverArtRequest(int id) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/PlayerSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/PlayerSettingsController.java
@@ -72,7 +72,7 @@ public class PlayerSettingsController  {
         User user = securityService.getCurrentUser(request);
         PlayerSettingsCommand command = new PlayerSettingsCommand();
         Player player = null;
-        Integer playerId = ServletRequestUtils.getIntParameter(request, "id");
+        Integer playerId = ServletRequestUtils.getIntParameter(request, "id", null);
         if (playerId != null) {
             player = playerService.getPlayerById(playerId);
         } else if (!players.isEmpty()) {
@@ -153,9 +153,15 @@ public class PlayerSettingsController  {
 
     private void handleRequestParameters(HttpServletRequest request) throws Exception {
         if (request.getParameter("delete") != null) {
-            playerService.removePlayerById(ServletRequestUtils.getIntParameter(request, "delete"));
+            Integer id = ServletRequestUtils.getIntParameter(request, "delete", null);
+            if (id != null) {
+                playerService.removePlayerById(id);
+            }
         } else if (request.getParameter("clone") != null) {
-            playerService.clonePlayer(ServletRequestUtils.getIntParameter(request, "clone"));
+            Integer id = ServletRequestUtils.getIntParameter(request, "clone", null);
+            if (id != null) {
+                playerService.clonePlayer(id);
+            }
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/PlaylistController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/PlaylistController.java
@@ -63,7 +63,10 @@ public class PlaylistController {
     protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response) throws Exception {
         Map<String, Object> map = new HashMap<>();
 
-        int id = ServletRequestUtils.getRequiredIntParameter(request, "id");
+        Integer id = ServletRequestUtils.getRequiredIntParameter(request, "id", null);
+        if (id == null) {
+            return new ModelAndView(new RedirectView("notFound"));
+        }
         User user = securityService.getCurrentUser(request);
         String username = user.getUsername();
         UserSettings userSettings = settingsService.getUserSettings(username);


### PR DESCRIPTION
The parameter `id` was parsed as a string, then
casted to an int. We're now directly parsing it as an
Integer instead, gracefully handling errors as a side-effect.