### PR TITLE
Move some video-cast-related inline js to an external file

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/videoPlayer.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/videoPlayer.jsp
@@ -8,7 +8,7 @@
     <script type="text/javascript" src="<c:url value="/dwr/engine.js"/>"></script>
     <script type="text/javascript" src="<c:url value="/dwr/interface/starService.js"/>"></script>
     <script type="text/javascript" src="<c:url value="/script/cast_sender-v1.js"/>"></script>
-    <%@ include file="videoPlayerCast.jsp" %>
+    <script type="text/javascript" src="<c:url value="/script/videoPlayerCast.js"/>"></script>
 
     <script type="text/javascript" language="javascript">
         function toggleStar(mediaFileId, imageId) {

--- a/airsonic-main/src/main/webapp/script/videoPlayerCast.js
+++ b/airsonic-main/src/main/webapp/script/videoPlayerCast.js
@@ -1,5 +1,3 @@
-<script type="text/javascript">
-
 (function () {
     'use strict';
 
@@ -692,4 +690,3 @@
 
     window.CastPlayer = CastPlayer;
 })();
-</script>


### PR DESCRIPTION
There is no point in having such a massive blob of javascript inline in the page.