### PR TITLE
Add a permission check for the podcast folder

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -693,6 +693,10 @@ public class PodcastService {
         File podcastDir = new File(settingsService.getPodcastFolder());
         File channelDir = new File(podcastDir, StringUtil.fileSystemSafe(channel.getTitle()));
 
+        if (!podcastDir.canWrite()) {
+          throw new RuntimeException("The podcasts directory " + podcastDir + " isn't writeable.");
+        }
+
         if (!channelDir.exists()) {
             boolean ok = channelDir.mkdirs();
             if (!ok) {


### PR DESCRIPTION
This should make podcast-related stacktraces a bit
more obvious to debug for users.