### PR TITLE
Fix cancel button colors in 'Groove' dark theme

### DIFF
--- a/airsonic-main/src/main/webapp/style/groove.css
+++ b/airsonic-main/src/main/webapp/style/groove.css
@@ -77,6 +77,11 @@ a:link, a:active, a:visited, a:link *, a:active *, a:visited * {
     color: #FFFFFF;
 }
 
+/* Button colors */
+input[type="button"] {
+    color: #000000;
+}
+
 /* Link hover colour */
 a:hover, a:hover * {
     text-decoration: underline;


### PR DESCRIPTION
Before:

![Screenshot from 2019-04-22 15-19-01](https://user-images.githubusercontent.com/613594/56502256-02110f80-6512-11e9-831f-a883585edd78.png)

After:

![Screenshot from 2019-04-22 15-24-08](https://user-images.githubusercontent.com/613594/56502475-b3b04080-6512-11e9-8c2d-fb8900848d7a.png)