### PR TITLE
CVE-2019-0232

### DIFF
--- a/airsonic-main/cve-suppressed.xml
+++ b/airsonic-main/cve-suppressed.xml
@@ -9,6 +9,23 @@
     </suppress>
     <!-- << Provisional -->
 
+    <!-- False positive for tomcat-jsp-api-8.5.40 -->
+    <suppress>
+        <notes><![CDATA[This issue is a packaging problem for Linux distributions]]></notes>
+        <gav regex="true">^.*$</gav>
+        <cve>CVE-2016-6325</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[This issue is a packaging problem for Linux distributions]]></notes>
+        <gav regex="true">^.*$</gav>
+        <cve>CVE-2016-5425</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[Not a vulnerability in Tomcat]]></notes>
+        <gav regex="true">^.*$</gav>
+        <cve>CVE-2017-6056</cve>
+    </suppress>
+
     <suppress>
         <notes><![CDATA[RC4 vulnerability in ssl. We don't use ssl at the application container level]]></notes>
         <gav regex="true">^.*$</gav>

--- a/airsonic-main/cve-suppressed.xml
+++ b/airsonic-main/cve-suppressed.xml
@@ -9,21 +9,10 @@
     </suppress>
     <!-- << Provisional -->
 
-    <!-- False positive for tomcat-jsp-api-8.5.40 -->
     <suppress>
-        <notes><![CDATA[This issue is a packaging problem for Linux distributions]]></notes>
+        <notes><![CDATA[CGI is not used]]></notes>
         <gav regex="true">^.*$</gav>
-        <cve>CVE-2016-6325</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[This issue is a packaging problem for Linux distributions]]></notes>
-        <gav regex="true">^.*$</gav>
-        <cve>CVE-2016-5425</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[Not a vulnerability in Tomcat]]></notes>
-        <gav regex="true">^.*$</gav>
-        <cve>CVE-2017-6056</cve>
+        <cve>CVE-2019-0232</cve>
     </suppress>
 
     <suppress>

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <chameleon.version>1.2.1-RELEASE</chameleon.version>
         <tomcat.server.scope>provided</tomcat.server.scope>
-        <tomcat.version>8.5.40</tomcat.version>
     </properties>
 
     <dependencies>
@@ -81,13 +80,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
-            <exclusions>
-                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
-                <exclusion>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-jdbc</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -483,100 +475,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
             <scope>${tomcat.server.scope}</scope>
-            <exclusions>
-                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-jasper</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-el</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-websocket</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-jdbc</artifactId>
-                </exclusion>
-               </exclusions> 
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
             <scope>${tomcat.server.scope}</scope>
-            <version>${tomcat.version}</version>
-            <exclusions>
-                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-el</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-websocket</artifactId>
-            <scope>${tomcat.server.scope}</scope>
-            <version>${tomcat.version}</version>
-            <exclusions>
-                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-            <scope>${tomcat.server.scope}</scope>
-            <version>${tomcat.version}</version>
-            <exclusions>
-                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
-                <exclusion>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-annotations-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-annotations-api</artifactId>
-            <scope>${tomcat.server.scope}</scope>
-            <version>${tomcat.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-el</artifactId>
-            <scope>${tomcat.server.scope}</scope>
-            <version>${tomcat.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-jdbc</artifactId>
-            <scope>${tomcat.server.scope}</scope>
-            <version>${tomcat.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-jsp-api</artifactId>
-            <scope>${tomcat.server.scope}</scope>
-            <version>${tomcat.version}</version>
         </dependency>
         <!-- Embedded Jetty -->
         <dependency>

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <chameleon.version>1.2.1-RELEASE</chameleon.version>
         <tomcat.server.scope>provided</tomcat.server.scope>
+        <tomcat.version>8.5.40</tomcat.version>
     </properties>
 
     <dependencies>
@@ -80,6 +81,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
+            <exclusions>
+                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-jdbc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -475,11 +483,100 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
             <scope>${tomcat.server.scope}</scope>
+            <exclusions>
+                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-jasper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-websocket</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-jdbc</artifactId>
+                </exclusion>
+               </exclusions> 
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
             <scope>${tomcat.server.scope}</scope>
+            <version>${tomcat.version}</version>
+            <exclusions>
+                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-el</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <scope>${tomcat.server.scope}</scope>
+            <version>${tomcat.version}</version>
+            <exclusions>
+                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <scope>${tomcat.server.scope}</scope>
+            <version>${tomcat.version}</version>
+            <exclusions>
+                <!-- interim : to able to use tomcat 8.5.40 on dependencies-1.5.20 -->
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-annotations-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-annotations-api</artifactId>
+            <scope>${tomcat.server.scope}</scope>
+            <version>${tomcat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-el</artifactId>
+            <scope>${tomcat.server.scope}</scope>
+            <version>${tomcat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jdbc</artifactId>
+            <scope>${tomcat.server.scope}</scope>
+            <version>${tomcat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jsp-api</artifactId>
+            <scope>${tomcat.server.scope}</scope>
+            <version>${tomcat.version}</version>
         </dependency>
         <!-- Embedded Jetty -->
         <dependency>


### PR DESCRIPTION
Fix to avoid compilation problems currently occurring with snapshots.

## Summary

The version of tomcat currently used by Airsonic is 8.5.39.
CVE-2019-0232 has been reported.

There are several workarounds.
 - Tomcat update. Modifications to airsonic-main/pom.xml and airsonic-main/cve-suppressed.xml are required.
 - Suppress only CVE-2019-0232.
___

### first commit(When updating tomcat)

#### airsonic-main/pom.xml

Add dependency to use tomcat 8.5.40 on dependencies-1.5.20.
Inevitably it is redundant..

#### airsonic-main/cve-suppressed.xml

Even if it is rewritten to tomcat 8.5.40, another problem occurs continuously.
Add 3 suppressionws.

https://nvd.nist.gov/vuln/detail/CVE-2016-6325
https://nvd.nist.gov/vuln/detail/CVE-2016-5425
https://nvd.nist.gov/vuln/detail/CVE-2017-6056

##### [CVE-2016-6325, CVE-2016-5425]
False positive for tomcat-jsp-api-8.5.40.
Tomcat from the Apache Tomcat project is not covered by this vulnerability.
This issue is a packaging problem for Linux distributions.

##### [CVE-2017-6056 -> False positive for tomcat-jsp-api-8.5.40]
False positive for tomcat-jsp-api-8.5.40
Not a vulnerability in Tomcat.

There is an official statement.
http://tomcat.apache.org/security-8.html

### second commit(Minimal addition)
Because the threat is limited.
