### PR TITLE
Fix for Issue 608

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -4,7 +4,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <property name="binary_type" dbms="hsqldb" value="binary" />
     <property name="binary_type" value="blob" />
-    <property name="curr_date_expr" value="current_timestamp" />
+    <property name="curr_date_expr" value="NULL" />
     <property name="varchar_type" dbms="mysql" value="varchar(${mysqlVarcharLimit})" />
     <property name="varchar_type" value="varchar" />
     <include file="legacy/legacy-changelog.xml" relativeToChangelogFile="true"/>

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema35.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema35.xml
@@ -71,7 +71,7 @@
             </column>
             <column name="name" type="${varchar_type}" />
             <column name="created_date" type="datetime" defaultValueComputed="${curr_date_expr}">
-                <constraints nullable="false" />
+                <constraints nullable="true" />
             </column>
             <column name="mime_type" type="${varchar_type}" >
                 <constraints nullable="false" />
@@ -102,7 +102,7 @@
             </column>
             <column name="name" type="${varchar_type}"/>
             <column name="created_date" type="datetime" defaultValueComputed="${curr_date_expr}">
-                <constraints nullable="false" />
+                <constraints nullable="true" />
             </column>
             <column name="mime_type" type="${varchar_type}" >
                 <constraints nullable="false" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema37.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema37.xml
@@ -2,7 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-    <property name="curr_date_expr" value="current_timestamp" />
+    <property name="curr_date_expr" value="NULL" />
     <changeSet id="schema37_001" author="muff1nman">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from version where version = 13</sqlCheck>
@@ -50,7 +50,7 @@
         </preConditions>
         <addColumn tableName="music_folder">
             <column name="changed" type="datetime" defaultValueComputed="${curr_date_expr}">
-                <constraints nullable="false" />
+                <constraints nullable="true" />
             </column>
         </addColumn>
     </changeSet>
@@ -62,7 +62,7 @@
         </preConditions>
         <addColumn tableName="internet_radio">
             <column name="changed" type="datetime" defaultValueComputed="${curr_date_expr}">
-                <constraints nullable="false" />
+                <constraints nullable="true" />
             </column>
         </addColumn>
     </changeSet>
@@ -74,7 +74,7 @@
         </preConditions>
         <addColumn tableName="user_settings">
             <column name="changed" type="datetime" defaultValueComputed="${curr_date_expr}">
-                <constraints nullable="false" />
+                <constraints nullable="true" />
             </column>
         </addColumn>
     </changeSet>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <failOnDependencyWarning>true</failOnDependencyWarning>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cxf.version>3.2.6</cxf.version>
+        <cxf.version>3.2.8</cxf.version>
         <jackson.version>2.9.8</jackson.version>
     </properties>
 


### PR DESCRIPTION
applied fixed to legacy table creations that allows mysql/mariadb to not fail. Also updated cxf.version to 3.2.8 as it seems 3.2.6 is no longer available when trying to package the project.

This seems to be a cleaner fix than what was mentioned in issue #608 