### PR TITLE
Fix typo in username displayed when playing shared media

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/security/JWTAuthenticationToken.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/JWTAuthenticationToken.java
@@ -6,8 +6,11 @@ import org.springframework.security.core.GrantedAuthority;
 import java.util.Collection;
 
 public class JWTAuthenticationToken extends AbstractAuthenticationToken {
+
     private final String token;
     private String requestedPath;
+
+    public static final String USERNAME_ANONYMOUS = "anonymous";
 
     public JWTAuthenticationToken(Collection<? extends GrantedAuthority> authorities, String token, String requestedPath) {
         super(authorities);
@@ -22,7 +25,7 @@ public class JWTAuthenticationToken extends AbstractAuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return "GERNIC_JWT_PRINICPLE";
+        return USERNAME_ANONYMOUS;
     }
 
     public String getRequestedPath() {


### PR DESCRIPTION
What do you think of changing the username displayed when someone is listening to shared media to `anonymous`? This should fix #663, in addition to fixing a weird typo (`GERNIC_JWT_PRINCIPLE`) and an obscure name.

Other options I thought about were `guest`, `external`, `shared`.

Not sure if we should allow a user to have the same username, is that something we want to prevent at user creation? In theory it should not change anything, but...