### PR TITLE
Jetty is only used by developers, and never in production

### DIFF
--- a/airsonic-main/cve-suppressed.xml
+++ b/airsonic-main/cve-suppressed.xml
@@ -49,9 +49,9 @@
 
     <!-- Jetty is currently only used for developer experimentation -->
     <suppress>
-        <notes><![CDATA[file name: jetty-schemas-3.1.jar]]></notes>
-        <gav regex="true">^org\.eclipse\.jetty\.toolchain:jetty-schemas:.*$</gav>
-        <cve>CVE-2017-9735</cve>
+        <notes>Jetty is currently only used for developer experimentations</notes>
+        <gav regex="true">^org\.eclipse\.jetty:.*$</gav>
+        <cpe>cpe:/a:org.eclipse.jetty:</cpe>
     </suppress>
 
     <!-- No git functionality is used from the following dependencies -->


### PR DESCRIPTION
So we're free to completely ignore CVE affecting it.