### PR TITLE
Fix #1077, spaces instead of coma in systemd lists

### DIFF
--- a/contrib/airsonic.service
+++ b/contrib/airsonic.service
@@ -35,7 +35,7 @@ ProtectKernelTunables=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictNamespaces=yes
 RestrictRealtime=yes
-SystemCallFilter=~@clock,@debug,@module,@mount,@obsolete,@privileged,@reboot,@setuid,@swap
+SystemCallFilter=~@clock @debug @module @mount @obsolete @privileged @reboot @setuid @swap
 ProtectSystem=full
 
 # You can uncomment the following line if you don't want airsonic to be able to 


### PR DESCRIPTION
From systemd man pages https://www.freedesktop.org/software/systemd/man/systemd.exec.html#System%20Call%20Filtering
