### PR TITLE
Fix remaining issues with playback stopping intermittently

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -577,6 +577,12 @@
         // the 'createMediaElementPlayer()' function above.
         //
         // player.play();
+
+        // FIXME: Remove once https://github.com/mediaelement/mediaelement/issues/2650 is fixed.
+        //
+        // Instead, we're triggering a 'waiting' event so that the player shows
+        // a progress bar to indicate that it's loading the stream.
+        player.dispatchEvent(new Event("waiting"));
     }
 
     function skip(index, position) {

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -52,7 +52,7 @@
                 }
             }});
 
-        <c:if test="${model.player.web}">createPlayer();</c:if>
+        <c:if test="${model.player.web}">createMediaElementPlayer();</c:if>
 
         $("#playlistBody").sortable({
             stop: function(event, ui) {
@@ -145,8 +145,21 @@
         onNext(repeatEnabled);
     }
 
-    function createPlayer() {
-        $('#audioPlayer').get(0).addEventListener("ended", onEnded);
+    function createMediaElementPlayer() {
+
+        var player = $('#audioPlayer').get(0);
+
+        // Once playback reaches the end, go to the next song, if any.
+        player.addEventListener("ended", onEnded);
+
+        // FIXME: Remove once https://github.com/mediaelement/mediaelement/issues/2650 is fixed.
+        //
+        // Once a media is loaded, we can start playback, but not before.
+        //
+        // Trying to start playback after a song has endred but before the
+        // 'canplay' event for the next song currently causes a race condition
+        // in the MediaElement.js player (4.2.10).
+        player.addEventListener("canplay", function() { player.play(); });
     }
 
     function getPlayQueue() {
@@ -532,6 +545,40 @@
         }
     }
 
+    function loadMediaElementPlayer(song, position) {
+        var player = $('#audioPlayer').get(0);
+
+        // Is this a new song?
+        if (player.src != song.streamUrl) {
+            // Stop the current playing song and change the media source.
+            player.src = song.streamUrl;
+            // Inform MEJS that we need to load a new media source. The
+            // 'canplay' event will be fired once playback is possible.
+            player.load();
+            // The 'skip' function takes a 'position' argument. We don't
+            // usually send it, and in this case it's better to do nothing.
+            // Otherwise, the 'canplay' event will also be fired after
+            // setting 'currentTime'.
+            if (position && position > 0) {
+                player.currentTime = position;
+            }
+
+        // Are we seeking on an already-playing song?
+        } else {
+            // Seeking also starts playing. The 'canplay' event will be
+            // fired after setting 'currentTime'.
+            player.currentTime = position || 0;
+        }
+
+        // FIXME: Uncomment once https://github.com/mediaelement/mediaelement/issues/2650 is fixed.
+        //
+        // Calling 'player.play()' at this point may work by chance, but it's
+        // not guaranteed in the current MediaElement.js player (4.2.10).  See
+        // the 'createMediaElementPlayer()' function above.
+        //
+        // player.play();
+    }
+
     function skip(index, position) {
         if (index < 0 || index >= songs.length) {
             return;
@@ -541,16 +588,12 @@
         currentStreamUrl = song.streamUrl;
         updateCurrentImage();
 
+        // Handle ChromeCast player.
         if (CastPlayer.castSession) {
             CastPlayer.loadCastMedia(song, position);
+        // Handle MediaElement (HTML5) player.
         } else {
-            if ($('#audioPlayer').get(0).src != song.streamUrl) {
-                $('#audioPlayer').get(0).src = song.streamUrl;
-                $('#audioPlayer').get(0).load();
-                console.log(song.streamUrl);
-            }
-            $('#audioPlayer').get(0).currentTime = position ? position : 0;
-            $('#audioPlayer').get(0).play();
+            loadMediaElementPlayer(song, position);
         }
 
         updateWindowTitle(song);


### PR DESCRIPTION
This is a follow-up of #1035 and #685, and I would love some testers on this!

@tari's patch helped a lot, but I was still seeing intermittent playback failures when switching songs, though not always and not with the same message...

I'm now fairly sure that this is caused by some of our JS code trying to run `play()` while the player is still loading the stream, causing a race condition.

I experimented a bit with the `skip(index, position)` function at the core of the play queue and added some logging to the player. I came to the conclusion that some methods (I identified `player.play()`, `player.load()` or setting `player.currentTime`) will automatically start loading the stream in the background, and calling any of them while the player is still loading will crash and burn.

The following screenshot shows the player load a first stream, then a a second (see both logs from `playQueue.view`) ; the request is then interrupted by something else and the player does not try again.

![Screenshot from 2019-05-24 00-52-30](https://user-images.githubusercontent.com/613594/58291689-9fd05680-7dbe-11e9-8569-e6f35ebcd070.png)

The following patch makes sure that all code paths in `skip` load *AND* start the stream exactly once, and _then_ start playback when the _canplay_ event fires. This appears to fix everything for me. Tested on FF 68 and Chromium 74.