### PR TITLE
Show missing Chromecast cover art (at full size)

### DIFF
--- a/airsonic-main/src/main/webapp/script/playQueueCast.js
+++ b/airsonic-main/src/main/webapp/script/playQueueCast.js
@@ -154,7 +154,7 @@
         mediaInfo.metadata.albumName = song.album;
         mediaInfo.metadata.artist = song.artist;
         mediaInfo.metadata.trackNumber = song.trackNumber;
-        mediaInfo.metadata.images = [new chrome.cast.Image(song.remoteCoverArtUrl + "&size=384")];
+        mediaInfo.metadata.images = [new chrome.cast.Image(song.remoteCoverArtUrl)];
         mediaInfo.metadata.releaseYear = song.year;
 
         var request = new chrome.cast.media.LoadRequest(mediaInfo);


### PR DESCRIPTION
This fixes a problem where Chromecast cover art was not showing up on the receiver. For whatever reason, the URL that was being generated was right, but the addition of a size specification was resulting in a redirect to the Airsonic login page with an "Incorrect username or password" message.

This removes the size specification (which seems to be a net benefit to me?) and gets the album art working again.

This fixes the second bullet from:
  - https://www.reddit.com/r/airsonic/comments/brf7rm/airsonic_1031/eog2omd/