### PR TITLE
Fix downloads with embedded covers

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -235,7 +235,7 @@ public class DownloadController implements LastModified {
         for (MediaFile mediaFile : filesToDownload) {
             zip(out, mediaFile.getParentFile(), mediaFile.getFile(), status, range);
             if (coverArtFile != null && coverArtFile.exists()) {
-                if (mediaFile.getFile().getCanonicalPath() == coverArtFile.getCanonicalPath()) {
+                if (mediaFile.getFile().getCanonicalPath().equals(coverArtFile.getCanonicalPath())) {
                     cover_embedded = true;
                 }
             }


### PR DESCRIPTION
Previously, this would always fail with embedded covers.