### PR TITLE
Disallow deleting your own user or removing admin role

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/command/UserSettingsCommand.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/command/UserSettingsCommand.java
@@ -46,6 +46,7 @@ public class UserSettingsCommand {
 
     private List<User> users;
     private boolean isAdmin;
+    private boolean isCurrentUser;
     private boolean isPasswordChange;
     private boolean isNewUser;
     private boolean isDeleteUser;
@@ -164,6 +165,14 @@ public class UserSettingsCommand {
 
     public void setAdmin(boolean admin) {
         isAdmin = admin;
+    }
+
+    public boolean isCurrentUser() {
+        return isCurrentUser;
+    }
+
+    public void setCurrentUser(boolean currentUser) {
+        isCurrentUser = currentUser;
     }
 
     public boolean isPasswordChange() {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/UserSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/UserSettingsController.java
@@ -87,6 +87,7 @@ public class UserSettingsController {
                 UserSettings userSettings = settingsService.getUserSettings(user.getUsername());
                 command.setTranscodeSchemeName(userSettings.getTranscodeScheme().name());
                 command.setAllowedMusicFolderIds(Util.toIntArray(getAllowedMusicFolderIds(user)));
+                command.setCurrentUser(securityService.getCurrentUser(request).getUsername().equals(user.getUsername()));
             } else {
                 command.setNewUser(true);
                 command.setStreamRole(true);

--- a/airsonic-main/src/main/java/org/airsonic/player/validator/UserSettingsValidator.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/validator/UserSettingsValidator.java
@@ -29,6 +29,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * Validator for {@link UserSettingsController}.
  *
@@ -41,6 +43,8 @@ public class UserSettingsValidator implements Validator {
     private SecurityService securityService;
     @Autowired
     private SettingsService settingsService;
+    @Autowired
+    private HttpServletRequest request;
 
     /**
      * {@inheritDoc}
@@ -83,6 +87,16 @@ public class UserSettingsValidator implements Validator {
 
         if (command.isPasswordChange() && command.isLdapAuthenticated()) {
             errors.rejectValue("password", "usersettings.passwordnotsupportedforldap");
+        }
+
+        if (securityService.getCurrentUser(request).getUsername().equals(username)) {
+            // These errors don't need translation since the option isn't exposed to the user
+            if (command.isDeleteUser()) {
+                errors.rejectValue("deleteUser", null, "Cannot delete the current user");
+            }
+            if (! command.isAdminRole()) {
+                errors.rejectValue("adminRole", null, "Cannot remove admin from the current user");
+            }
         }
 
     }

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/userSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/userSettings.jsp
@@ -66,6 +66,7 @@
             <tr style="${command.currentUser ? 'display:none' : ''}">
                 <td><form:checkbox path="adminRole" id="admin" cssClass="checkbox"/></td>
                 <td><label for="admin"><fmt:message key="usersettings.admin"/></label></td>
+                <td class="warning"><form:errors path="adminRole"/></td>
             </tr>
             <tr>
                 <td><form:checkbox path="settingsRole" id="settings" cssClass="checkbox"/></td>
@@ -141,6 +142,7 @@
             <tr>
                 <td><form:checkbox path="deleteUser" id="delete" cssClass="checkbox"/></td>
                 <td><label for="delete"><fmt:message key="usersettings.delete"/></label></td>
+                <td class="warning"><form:errors path="deleteUser"/></td>
             </tr>
         </table>
     </c:if>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/userSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/userSettings.jsp
@@ -63,7 +63,7 @@
 
 <form:form method="post" action="userSettings.view" modelAttribute="command">
         <table style="${command.admin ? 'display:none' : ''}">
-            <tr>
+            <tr style="${command.currentUser ? 'display:none' : ''}">
                 <td><form:checkbox path="adminRole" id="admin" cssClass="checkbox"/></td>
                 <td><label for="admin"><fmt:message key="usersettings.admin"/></label></td>
             </tr>
@@ -136,7 +136,7 @@
         </tr>
     </table>
 
-    <c:if test="${not command.newUser and not command.admin}">
+    <c:if test="${not command.newUser and not command.admin and not command.currentUser}">
         <table class="indent">
             <tr>
                 <td><form:checkbox path="deleteUser" id="delete" cssClass="checkbox"/></td>


### PR DESCRIPTION
It makes no sense and is potentially dangerous to allow a user to delete their own account, or to be able to remove the admin role from themselves, so this removes the ability to do so.