### PR TITLE
Added ability to delete the default admin user

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/LoginController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/LoginController.java
@@ -51,9 +51,11 @@ public class LoginController {
         map.put("brand", settingsService.getBrand());
         map.put("loginMessage", settingsService.getLoginMessage());
 
-        User admin = securityService.getUserByName(User.USERNAME_ADMIN);
-        if (User.USERNAME_ADMIN.equals(admin.getPassword())) {
-            map.put("insecure", true);
+        User admin = securityService.getUserByName("admin");
+        if (admin != null) {
+            if (admin.getUsername().equals(admin.getPassword())) {
+                map.put("insecure", true);
+            }
         }
 
         return new ModelAndView("login", "model", map);

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -2093,7 +2093,10 @@ public class SubsonicRESTController {
         if (u == null) {
             error(request, response, ErrorCode.NOT_FOUND, "No such user: " + username);
             return;
-        } else if (org.airsonic.player.domain.User.USERNAME_ADMIN.equals(username)) {
+        } else if (user.getUsername().equals(username)) {
+            error(request, response, ErrorCode.NOT_AUTHORIZED, "Not allowed to change own user");
+            return;
+        } else if (securityService.isAdmin(username)) {
             error(request, response, ErrorCode.NOT_AUTHORIZED, "Not allowed to change admin user");
             return;
         }
@@ -2145,7 +2148,15 @@ public class SubsonicRESTController {
         }
 
         String username = getRequiredStringParameter(request, "username");
-        if (org.airsonic.player.domain.User.USERNAME_ADMIN.equals(username)) {
+        org.airsonic.player.domain.User u = securityService.getUserByName(username);
+
+        if (u == null) {
+            error(request, response, ErrorCode.NOT_FOUND, "No such user: " + username);
+            return;
+        } else if (user.getUsername().equals(username)) {
+            error(request, response, ErrorCode.NOT_AUTHORIZED, "Not allowed to delete own user");
+            return;
+        } else if (securityService.isAdmin(username)) {
             error(request, response, ErrorCode.NOT_AUTHORIZED, "Not allowed to delete admin user");
             return;
         }

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
@@ -147,10 +147,6 @@ public class UserDao extends AbstractDao {
      * @param username The username.
      */
     public void deleteUser(String username) {
-        if (User.USERNAME_ADMIN.equals(username)) {
-            throw new IllegalArgumentException("Can't delete admin user.");
-        }
-
         update("delete from user_role where username=?", username);
         update("delete from player where username=?", username);
         update("delete from " + getUserTable() + " where username=?", username);

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/User.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/User.java
@@ -26,7 +26,6 @@ package org.airsonic.player.domain;
  */
 public class User {
 
-    public static final String USERNAME_ADMIN = "admin";
     public static final String USERNAME_GUEST = "guest";
 
     private final String username;
@@ -125,7 +124,7 @@ public class User {
     }
 
     public boolean isSettingsRole() {
-        return isSettingsRole;
+        return isAdminRole || isSettingsRole;
     }
 
     public void setSettingsRole(boolean isSettingsRole) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistService.java
@@ -27,7 +27,6 @@ import org.airsonic.player.dao.PlaylistDao;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.PlayQueue;
 import org.airsonic.player.domain.Playlist;
-import org.airsonic.player.domain.User;
 import org.airsonic.player.service.playlist.PlaylistExportHandler;
 import org.airsonic.player.service.playlist.PlaylistImportHandler;
 import org.airsonic.player.util.FileUtil;
@@ -296,7 +295,9 @@ public class PlaylistService {
         }
         InputStream in = new FileInputStream(file);
         try {
-            importPlaylist(User.USERNAME_ADMIN, FilenameUtils.getBaseName(fileName), fileName, in, existingPlaylist);
+            // With the transition away from a hardcoded admin account to Admin Roles, there is no longer
+            //   a specific account to use for auto-imported playlists, so use the first admin account
+            importPlaylist(securityService.getAdminUsername(), FilenameUtils.getBaseName(fileName), fileName, in, existingPlaylist);
             LOG.info("Auto-imported playlist " + file);
         } finally {
             FileUtil.closeQuietly(in);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -166,11 +166,22 @@ public class SecurityService implements UserDetailsService {
      * Returns whether the given user has administrative rights.
      */
     public boolean isAdmin(String username) {
-        if (User.USERNAME_ADMIN.equals(username)) {
-            return true;
-        }
         User user = getUserByName(username);
         return user != null && user.isAdminRole();
+    }
+
+    /**
+     * Returns username with admin rights.
+     *
+     * @return username of admin user
+     */
+    public String getAdminUsername() {
+        for (User user : userDao.getAllUsers()) {
+            if (user.isAdminRole()) {
+                return user.getUsername();
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
This transitions to solely using Admin Roles rather than a hardcoded admin
account.  This allows for deleting the initial admin account, which had
previously been a security weakness since the account name was not able to
be changed.  Fixes #640.