### PR TITLE
Handle LyricsService exceptions

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/LyricsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/LyricsService.java
@@ -25,6 +25,7 @@ import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -79,7 +80,7 @@ public class LyricsService {
             if (x.getStatusCode() == 503) {
                 lyrics.setTryLater(true);
             }
-        } catch (SocketException x) {
+        } catch (SocketException | ConnectTimeoutException x) {
             LOG.warn("Failed to get lyrics for song '{}': {}", song, x.toString());
             lyrics.setTryLater(true);
         } catch (Exception x) {

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/LyricsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/LyricsService.java
@@ -21,6 +21,7 @@ package org.airsonic.player.ajax;
 
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
@@ -73,7 +74,13 @@ public class LyricsService {
             String xml = executeGetRequest(url);
             lyrics = parseSearchResult(xml);
 
+        } catch (HttpResponseException x) {
+            LOG.warn("Failed to get lyrics for song '{}'. Request failed: {}", song, x.toString());
+            if (x.getStatusCode() == 503) {
+                lyrics.setTryLater(true);
+            }
         } catch (SocketException x) {
+            LOG.warn("Failed to get lyrics for song '{}': {}", song, x.toString());
             lyrics.setTryLater(true);
         } catch (Exception x) {
             LOG.warn("Failed to get lyrics for song '" + song + "'.", x);


### PR DESCRIPTION
This fixes the huge traceback problem when there is an error returned from the lyrics server that is exhibited in #1144, but doesn't address the underlying problem of why the lyrics fetches are failing in this manner.