### PR TITLE
Suppress traceback for common null pointer exception

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -628,10 +628,10 @@ public class CoverArtController implements LastModified {
             try {
                 in = getImageInputStreamForVideo(mediaFile, width, height, offset);
                 BufferedImage result = ImageIO.read(in);
-                if (result == null) {
-                    throw new NullPointerException();
+                if (result != null) {
+                    return result;
                 }
-                return result;
+                LOG.warn("Failed to process cover art for " + mediaFile + ": {}", result);
             } catch (Throwable x) {
                 LOG.warn("Failed to process cover art for " + mediaFile + ": " + x, x);
             } finally {


### PR DESCRIPTION
This happens often with containers that support video but only contain audio.  The code raises the `NullPointerException` itself, so this just suppresses the traceback in that case.