### PR TITLE
Add sha256sums and gpg sign outside of maven process

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -634,6 +634,10 @@
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
             </plugin>
+            <plugin>
+                <groupId>net.nicoulaj.maven.plugins</groupId>
+                <artifactId>checksum-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/contrib/release.md
+++ b/contrib/release.md
@@ -20,37 +20,41 @@ Release Steps
 
 6. Package
 
-        mvn clean verify -P docker,sign
+        mvn clean verify -P docker
 
-7. push up branch and tag
+7. Sign sha256sums file
+
+        gpg2 --clearsign artifacts-checksums.sha
+
+8. push up branch and tag
 
         git push origin vX.Y.Z
         git push -u origin release-X.Y
 
-8. Create new release on github
+9. Create new release on github
 
    - Draft new Relase
    - Choose existing tag
    - Title is "Airsonic X.Y.Z"
    - Contents are the relevant entry of the CHANGELOG.md file
-   - Upload `airsonic.war` and `airsonic.war.asc`
+   - Upload `airsonic.war` and `artifacts-checksums.sha`
 
-9. Update latest docker tag
+10. Update latest docker tag
 
         docker tag airsonic/airsonic:X.Y.Z-RELEASE airsonic/airsonic:latest
 
-10. Docker login with airsonic credentials in `airsonic-passwords` repo
+11. Docker login with airsonic credentials in `airsonic-passwords` repo
 
         docker login
 
-11. Push images
+12. Push images
 
         docker push airsonic/airsonic:X.Y.Z-RELEASE
         docker push airsonic/airsonic:latest
 
-12. Checkout master branch and bump maven version to next snapshot version
+13. Checkout master branch and bump maven version to next snapshot version
 
         git checkout master
         mvn versions:set -DnewVersion=X.Y+1.0-SNAPSHOT
 
-13. Git commit and push
+14. Git commit and push

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -203,19 +203,6 @@
                     </includes>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,26 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>net.nicoulaj.maven.plugins</groupId>
+                    <artifactId>checksum-maven-plugin</artifactId>
+                    <version>1.8</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>artifacts</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <algorithms>
+                            <algorithm>SHA-256</algorithm>
+                        </algorithms>
+                        <individualFiles>false</individualFiles>
+                        <shasumSummary>true</shasumSummary>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -416,26 +436,6 @@
                 <module>install/docker</module>
                 <module>integration-test</module>
             </modules>
-        </profile>
-        <profile>
-            <id>sign</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Addresses #1073.

Also the reasoning for dropping the gpg sign profile is because the `maven-gpg-plugin` is really only designed to sign artifacts. However, with the sha256 summary file, it is really the only file that should be signed.

I have updated the docs accordingly.