### PR TITLE
Fix for paths stored in Lucene index

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -237,13 +237,13 @@ public class MediaScannerService {
 
         LOG.trace("Scanning file {}", file.getPath());
 
-        searchService.index(file);
-
         // Update the root folder if it has changed.
         if (!musicFolder.getPath().getPath().equals(file.getFolder())) {
             file.setFolder(musicFolder.getPath().getPath());
             mediaFileDao.createOrUpdateMediaFile(file);
         }
+
+        searchService.index(file);
 
         if (file.isDirectory()) {
             for (MediaFile child : mediaFileService.getChildrenOf(file, true, false, false, false)) {

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceSpecialPathTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceSpecialPathTestCase.java
@@ -69,14 +69,14 @@ public class SearchServiceSpecialPathTestCase extends AbstractAirsonicHomeTest {
                 .filter(m -> "accessible".equals(m.getName()))
                 .collect(Collectors.toList());
         randomAlbums = searchService.getRandomAlbums(Integer.MAX_VALUE, folder01);
-        Assert.assertEquals("Albums in \"accessible\" ", 3, randomAlbums.size());
+        Assert.assertEquals("Albums in \"accessible\" ", 1, randomAlbums.size());
 
         // dir - accessible's
         List<MusicFolder> folder02 = folders.stream()
                 .filter(m -> "accessible's".equals(m.getName()))
                 .collect(Collectors.toList());
         randomAlbums = searchService.getRandomAlbums(Integer.MAX_VALUE, folder02);
-        Assert.assertEquals("Albums in \"accessible's\" ", 0, randomAlbums.size());
+        Assert.assertEquals("Albums in \"accessible's\" ", 1, randomAlbums.size());
 
         // dir - accessible+s
         List<MusicFolder> folder03 = folders.stream()


### PR DESCRIPTION
The fix is ​​for the Lucene index.
It does not affect the record of Database.

There is a place to switch Path by recursive processing in Scan, and it is correctly registered in Database.

The same is true for Lucene indexes, but the processing order is incorrect.
Incorrect path may be registered in Lucene index.

This fix allows Lucene indexes to handle the correct path perfectly matched with the database,.

The bug of #1139 is resolved.
This bug seems to be a traditional bug .

 - Also occurs in Airsonic v10.0.0
 - Also occurs in Latest version of Subsonic 6.1.5 (build 759abe) – December 1, 2018

___

If this is merged before #1166, test case modifications should be incorporated into #1166.