### PR TITLE
Fixed null exception when attempt to stream non-file

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -128,7 +128,7 @@ public class StreamController {
             // In that case, create a separate playlist (in order to support multiple parallel streams).
             // Also, enable partial download (HTTP byte range).
             MediaFile file = getSingleFile(request);
-            boolean isSingleFile = file != null;
+            boolean isSingleFile = file != null && file.isFile();
             HttpRange range = null;
 
             if (isSingleFile) {


### PR DESCRIPTION
There are MediaFile entities (like directories) that would cause a null pointer exception if they were attempted to stream.