### PR TITLE
Fix podcast download issues

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -36,6 +36,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -551,6 +552,10 @@ public class PodcastService {
             RequestConfig requestConfig = RequestConfig.custom()
                     .setConnectTimeout(2 * 60 * 1000) // 2 minutes
                     .setSocketTimeout(10 * 60 * 1000) // 10 minutes
+                    // Workaround HttpClient circular redirects, which some feeds use (with query parameters)
+                    .setCircularRedirectsAllowed(true)
+                    // Workaround HttpClient not understanding latest RFC-compliant cookie 'expires' attributes
+                    .setCookieSpec(CookieSpecs.STANDARD)
                     .build();
             HttpGet method = new HttpGet(episode.getUrl());
             method.setConfig(requestConfig);


### PR DESCRIPTION
Some podcast feeds use circular redirects (with query parameters). Fixes #1013

Change HttpClient cookie handling to avoid producing "Invalid cookie" errors due to not handling latest "expires" attribute formats.
