### PR TITLE
Fix null exception when create new podcast channel

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -177,7 +177,8 @@ public class PodcastService {
      */
     public PodcastChannel getChannel(int channelId) {
         PodcastChannel channel = podcastDao.getChannel(channelId);
-        addMediaFileIdToChannels(Arrays.asList(channel));
+        if (channel.getTitle() != null)
+            addMediaFileIdToChannels(Arrays.asList(channel));
         return channel;
     }
 
@@ -272,6 +273,10 @@ public class PodcastService {
     private List<PodcastChannel> addMediaFileIdToChannels(List<PodcastChannel> channels) {
         for (PodcastChannel channel : channels) {
             try {
+                if (channel.getTitle() == null) {
+                    LOG.warn("Podcast channel id {} has null title", channel.getId());
+                    continue;
+                }
                 File dir = getChannelDirectory(channel);
                 MediaFile mediaFile = mediaFileService.getMediaFile(dir);
                 if (mediaFile != null) {


### PR DESCRIPTION
Until the podcast channel has been updated to provide it with a title, there is no point to doing any further processing since the directory where episodes are stored is derived from the title.

While this change is unrelated to #176, it fixes the traceback shown in that issue.