### PR TITLE
Replace a now-defunct repo with a working one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ matrix:
   include:
   - jdk: openjdk8
   - jdk: oraclejdk9
+    before_install:
+        # The OpenJDK9's CA bundle is outdated, so we're using the system's ones.
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
   - jdk: openjdk11
   - jdk: openjdk12

--- a/pom.xml
+++ b/pom.xml
@@ -28,19 +28,16 @@
             <url>file://${project.basedir}/../repo</url>
         </repository>
         <repository>
-            <id>java_net</id>
-            <name>download.java.net</name>
-            <url>https://download.java.net/maven/2/</url>
-        </repository>
-        <repository>
-            <id>teleal</id>
-            <name>teleal</name>
-            <url>http://teleal.org/m2</url>
-        </repository>
-        <repository>
             <id>jaudiotagger-repository</id>
             <url>https://dl.bintray.com/ijabz/maven</url>
         </repository>
+        <repository>
+          <id>4thline-repo</id>
+          <url>http://4thline.org/m2</url>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+      </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
The http://teleal.org/m2 maven repository doesn't exist anymore (the domain is now a parking), so we should use http://4thline.org/m2 (which is the upstream for cling anyway) instead. But since the later uses some modern CA for its TLS cert, we need to modify where the OpenJDK9 is getting its CA from, since the bundled ones are outdated. This idea was stolen from https://www.deps.co/guides/travis-ci-latest-java/

This commit also remove `https://download.java.net/maven/2/`, since it's also dead: 404 all the way.
