### PR TITLE
Add a test skip temporarily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.0</version>
+                    <configuration>
+                        <!-- #1186 Add a test skip temporarily -->
+                        <excludes>org.airsonic.player.service.search.*TestCase.java</excludes>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>net.nicoulaj.maven.plugins</groupId>


### PR DESCRIPTION
In connection with #1186.
Skip testing the search package.

While this is effective for temporarily avoiding the problem at hand, it is not a fundamental solution.
In my environment, the first build failed with Java8 and Java9.

![Clipboard02](https://user-images.githubusercontent.com/27724847/62521490-b8eb8e00-b86a-11e9-95d7-c1633c0a83b7.gif)

Achieve green after retrying several times.

![Clipboard03](https://user-images.githubusercontent.com/27724847/62521508-c143c900-b86a-11e9-9a16-f06286470263.gif)

Even with this support, the build time seems too long.


___


Structurally, It seems that docker-test and verification (or Integration-test) for each JVM  is sufficient.
Most unit tests should only be done on a representative JVM, and in some cases it may be better to divide them into layers and run them in parallel.
(View/Controller/Model?)

Or define a test category.
(REST/Service/Database/Scan/Stream... etc?)
In this case, annotation management is generally preferred.
It is desirable to have a test utility project that holds annotations.

The travis build may be particularly slow from the end of last month.
We might want to hear muff1nman's opinion on test management.
