### PR TITLE
Remove the useless Zoom link

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/coverArt.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/coverArt.jsp
@@ -103,21 +103,13 @@ PARAMETERS
     </c:if>
 </div>
 
-<c:if test="${param.showChange or param.showZoom}">
+<c:if test="${param.showChange}">
     <div style="padding-top:6px;text-align:right">
         <c:if test="${param.showChange}">
             <c:url value="/changeCoverArt.view" var="changeCoverArtUrl">
                 <c:param name="id" value="${param.albumId}"/>
             </c:url>
             <a class="detail" href="${changeCoverArtUrl}"><fmt:message key="coverart.change"/></a>
-        </c:if>
-
-        <c:if test="${param.showZoom and param.showChange}">
-            |
-        </c:if>
-
-        <c:if test="${param.showZoom}">
-            <a class="detail" rel="zoom" title="${param.caption1}" href="${zoomCoverArtUrl}"><fmt:message key="coverart.zoom"/></a>
         </c:if>
     </div>
 </c:if>


### PR DESCRIPTION
![POUET](https://user-images.githubusercontent.com/325724/62654015-713e3280-b94e-11e9-9db8-c970fe660440.png)

- People can just click on the picture, having a dedicated link for this is obnoxious
- Clicking on the picture provides a nice zoom effect, while keeping airsonic in the background, instead of displaying only the picture, interrupting the playback.