### PR TITLE
normalize license expire date to prevent outstanding value on Java 12

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -426,6 +426,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
             <!-- commons-configuration2 requires during runtime -->
             <scope>runtime</scope>
         </dependency>

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -170,9 +170,10 @@ public class SubsonicRESTController {
 
         license.setEmail("airsonic@github.com");
         license.setValid(true);
-        Date neverExpireDate = new Date(Long.MAX_VALUE);
-        license.setLicenseExpires(jaxbWriter.convertDate(neverExpireDate));
-        license.setTrialExpires(jaxbWriter.convertDate(neverExpireDate));
+        Date farFuture = new Date();
+        farFuture.setYear(farFuture.getYear() + 100);
+        license.setLicenseExpires(jaxbWriter.convertDate(farFuture));
+        license.setTrialExpires(jaxbWriter.convertDate(farFuture));
 
         Response res = createResponse();
         res.setLicense(license);

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <failOnDependencyWarning>true</failOnDependencyWarning>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cxf.version>3.3.1</cxf.version>
-        <jackson.version>2.9.9</jackson.version>
         <tomcat.version>8.5.42</tomcat.version>
     </properties>
 
@@ -114,17 +113,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
+                <version>2.9.9</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>2.9.9.3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>2.9.9</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Date(Long.MAX_VALUE) is 292278994-08-17T07:12:55.807Z on Java 12, and
make [Ultrasonic](https://github.com/ultrasonic/ultrasonic) failed to parse.

Signed-off-by: Shen-Ta Hsieh <ibmibmibm.tw@gmail.com>