### PR TITLE
Fixed bug where new users were given access to all media folders

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -41,6 +41,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -180,7 +181,7 @@ public class SecurityService implements UserDetailsService {
      */
     public void createUser(User user) {
         userDao.createUser(user);
-        settingsService.setMusicFoldersForUser(user.getUsername(), MusicFolder.toIdList(settingsService.getAllMusicFolders()));
+        settingsService.setMusicFoldersForUser(user.getUsername(), MusicFolder.toIdList(Collections.emptyList()));
         LOG.info("Created user " + user.getUsername());
     }
 


### PR DESCRIPTION
Newly created users were previously given access to all media folders before the user was updated to only allow access for the folders specified in the submitted form.
This change now defaults to no access to any folders, in case a crash or exception occurs between when the user is created and the later update of the allowed folders.