### PR TITLE
Admin users now always get access to all media folders

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -241,6 +241,8 @@ public class SettingsService {
     private AvatarDao avatarDao;
     @Autowired
     private ApacheCommonsConfigurationService configurationService;
+    @Autowired
+    private SecurityService securityService;
 
     private String[] cachedCoverArtFileTypesArray;
     private String[] cachedMusicFileTypesArray;
@@ -963,6 +965,9 @@ public class SettingsService {
      */
     public List<MusicFolder> getMusicFoldersForUser(String username) {
         List<MusicFolder> result = cachedMusicFoldersPerUser.get(username);
+        if (securityService.isAdmin(username)) {
+            result = getAllMusicFolders(true, false);
+        }
         if (result == null) {
             result = musicFolderDao.getMusicFoldersForUser(username);
             result.retainAll(getAllMusicFolders(false, false));


### PR DESCRIPTION
It seems to be somewhat common that users will add new media folders and then
wonder why they can't see the contents, because they haven't enabled their
user to have access to the new folder(s).  This tries to improve that
situation by automatically granting all admin users access to all media
folders.