### PR TITLE
Improve search accuracy

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
@@ -74,7 +74,7 @@ public class IndexManager {
      *    DocumentFactory or the class that they use.
      *
      */
-    private static final int INDEX_VERSION = 16;
+    private static final int INDEX_VERSION = 17;
 
     /**
      * Literal name of index top directory.

--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexType.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexType.java
@@ -39,7 +39,7 @@ public enum IndexType {
             FieldNames.TITLE,
             FieldNames.ARTIST),
         boosts(
-            entry(FieldNames.TITLE, 2F))),
+            entry(FieldNames.TITLE, 1.1F))),
 
     ALBUM(
         fieldNames(
@@ -47,7 +47,7 @@ public enum IndexType {
             FieldNames.ARTIST), 
             // FieldNames.FOLDER), // XXX 3.x -> 8.x : Remove folder from multi-field search condition
         boosts(
-            entry(FieldNames.ALBUM, 2F))),
+            entry(FieldNames.ALBUM, 1.1F))),
 
     ALBUM_ID3(
         fieldNames(
@@ -55,20 +55,18 @@ public enum IndexType {
             FieldNames.ARTIST),
             // FieldNames.FOLDER_ID), // XXX 3.x -> 8.x : Remove folder from multi-field search condition
         boosts(
-            entry(FieldNames.ALBUM, 2F))),
+            entry(FieldNames.ALBUM, 1.1F))),
 
     ARTIST(
         fieldNames(
             FieldNames.ARTIST),
             // FieldNames.FOLDER), // XXX 3.x -> 8.x : Remove folder from multi-field search condition
-        boosts(
-            entry(FieldNames.ARTIST, 1F))),
+        boosts()),
 
     ARTIST_ID3(
         fieldNames(
             FieldNames.ARTIST),
-        boosts(
-            entry(FieldNames.ARTIST, 2F))),
+        boosts()),
 
     ;
 

--- a/airsonic-main/src/main/resources/org/airsonic/player/service/search/analysis/stopwords.txt
+++ b/airsonic-main/src/main/resources/org/airsonic/player/service/search/analysis/stopwords.txt
@@ -1,0 +1,37 @@
+# This file is part of Airsonic.
+#
+# Airsonic is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Airsonic is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright 2016 (C) Airsonic Authors
+
+# This file defines stop words suitable for music search.
+# See EnglishAnalyzer.ENGLISH_STOP_WORDS_SET for default stopwords.
+# 
+# a, an, and, are, as, at,
+# be, but, by, for, if, in,
+# into, is, it, no, not, of,
+# on, or, such, that, the,
+# their, then, there, these,
+# they, this, to, was, will,
+# with
+
+# Ignore articles that are used by default in the index.
+# See SettingsService.DEFAULT_IGNORED_ARTICLES
+
+a
+an
+the
+el
+las
+le
+les

--- a/airsonic-main/src/main/resources/org/airsonic/player/service/search/analysis/stopwords_artist.txt
+++ b/airsonic-main/src/main/resources/org/airsonic/player/service/search/analysis/stopwords_artist.txt
@@ -1,0 +1,45 @@
+# This file is part of Airsonic.
+#
+# Airsonic is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Airsonic is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright 2016 (C) Airsonic Authors
+
+# This file defines stop words suitable for music search.
+# See EnglishAnalyzer.ENGLISH_STOP_WORDS_SET for default stopwords.
+# 
+# a, an, and, are, as, at,
+# be, but, by, for, if, in,
+# into, is, it, no, not, of,
+# on, or, such, that, the,
+# their, then, there, these,
+# they, this, to, was, will,
+# with
+
+# Ignore articles that are used by default in the index.
+# See SettingsService.DEFAULT_IGNORED_ARTICLES
+
+a
+an
+the
+el
+las
+le
+les
+
+# Unique conjunctions often used in artist fields.
+
+by
+cv
+feat
+vs
+with

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
@@ -123,13 +123,13 @@ public class QueryFactoryTestCase {
 
         Query query = queryFactory.search(criteria, SINGLE_FOLDERS, IndexType.ALBUM);
         assertEquals("SearchAlbum",
-                "+((album:abc* artist:abc*) (album:def* artist:def*)) +(folder:" + PATH1
+                "+(((album:abc*)^1.1 artist:abc*) ((album:def*)^1.1 artist:def*)) +(folder:" + PATH1
                         + ")",
                 query.toString());
 
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM);
         assertEquals("SearchAlbum",
-                "+((album:abc* artist:abc*) (album:def* artist:def*)) +(folder:" + PATH1
+                "+(((album:abc*)^1.1 artist:abc*) ((album:def*)^1.1 artist:def*)) +(folder:" + PATH1
                         + " folder:" + PATH2 + ")",
                 query.toString());
     }
@@ -143,11 +143,11 @@ public class QueryFactoryTestCase {
 
         Query query = queryFactory.search(criteria, SINGLE_FOLDERS, IndexType.SONG);
         assertEquals("SearchSong",
-                "+((title:abc* artist:abc*) (title:def* artist:def*)) +(folder:" + PATH1 + ")",
+                "+(((title:abc*)^1.1 artist:abc*) ((title:def*)^1.1 artist:def*)) +(folder:" + PATH1 + ")",
                 query.toString());
 
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.SONG);
-        assertEquals("SearchSong", "+((title:abc* artist:abc*) (title:def* artist:def*)) +(folder:" + PATH1
+        assertEquals("SearchSong", "+(((title:abc*)^1.1 artist:abc*) ((title:def*)^1.1 artist:def*)) +(folder:" + PATH1
                 + " folder:" + PATH2 + ")", query.toString());
     }
 
@@ -178,13 +178,13 @@ public class QueryFactoryTestCase {
 
         Query query = queryFactory.search(criteria, SINGLE_FOLDERS, IndexType.ALBUM_ID3);
         assertEquals(
-                "SearchAlbumId3", "+((album:abc* artist:abc*) (album:def* artist:def*)) "
+                "SearchAlbumId3", "+(((album:abc*)^1.1 artist:abc*) ((album:def*)^1.1 artist:def*)) "
                         + "+(folderId:" + FID1 + ")",
                 query.toString());
 
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM_ID3);
         assertEquals("SearchAlbumId3",
-                "+((album:abc* artist:abc*) (album:def* artist:def*)) +(folderId:"
+                "+(((album:abc*)^1.1 artist:abc*) ((album:def*)^1.1 artist:def*)) +(folderId:"
                         + FID1 + " folderId:"
                         + FID2 + ")",
                 query.toString());

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceStartWithStopwardsTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceStartWithStopwardsTestCase.java
@@ -57,8 +57,8 @@ public class SearchServiceStartWithStopwardsTestCase extends AbstractAirsonicHom
 
         criteria.setQuery("will");
         SearchResult result = searchService.search(criteria, folders, IndexType.ARTIST_ID3);
-        // XXX 3.x -> 8.x : The filter is properly applied to the input(Stopward)
-        Assert.assertEquals("Williams hit by \"will\" ", 0, result.getTotalHits());
+        // Will hit because Airsonic's stopword is defined(#1235)
+        Assert.assertEquals("Williams hit by \"will\" ", 1, result.getTotalHits());
 
         criteria.setQuery("the");
         result = searchService.search(criteria, folders, IndexType.SONG);


### PR DESCRIPTION
Related to #1142.
This PR proposes the following two improvements.

 - Setting boost value. Legacy code was conscious of introduction, but it was dead code.
 - Airsonic-specific Stopward for music search.

In a search system, these are usually considered at design time.
The current search does n’t take into account the convenience of users who type short phrases.

Here is a simple example.
___


### Stopward change example

``Will`` cannot be used in legacy searches.

![image](https://user-images.githubusercontent.com/27724847/64922865-f7338000-d80e-11e9-94a4-60a9d340b784.png)


![image](https://user-images.githubusercontent.com/27724847/64922909-63ae7f00-d80f-11e9-9a97-2c7219b32a66.png)

___

## Example of boost value adjustment

It is reasonable to give priority to the leftmost item in the search results.
Since the boost value is assigned a very small value, the priority will be reversed if the cost of the Artist name is high.

### before

![image](https://user-images.githubusercontent.com/27724847/64923225-d4a36600-d812-11e9-8cce-d70703cd7017.png)

### after

![image](https://user-images.githubusercontent.com/27724847/64923202-9b6af600-d812-11e9-9751-a42380c31af2.png)

___

Brainstorm is required for the value set in Stopward.
(Particularly the opinions of English speaking people are necessary. Because I am Japanese.)

 - Once this is done, maintenance is easy and anyone can do it. For example, if you add a composer, you can give it a new priority.
 - Stopwords are assigned differently for Artist and other fields. This is because the words you want to ignore, such as `` feat``,  `` with``, are a little different.

@muff1nman 
 - Although not required, there are some considerations. This changes affect the index version. So if you release this PR at the same time as the Lucene update, users will be satisfied (If the release is divided, the index must be reconfigured.). This PR does not include increments.