### PR TITLE
Update media types supported by Jaudiotagger

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -361,15 +361,19 @@ public class JaudiotaggerParser extends MetaDataParser {
         String format = FilenameUtils.getExtension(file.getName()).toLowerCase();
 
         return "mp3".equals(format) ||
+               "mp4".equals(format) ||
                "m4a".equals(format) ||
                "m4b".equals(format) ||
+               "m4p".equals(format) ||
                "aac".equals(format) ||
                "ogg".equals(format) ||
-               "flac".equals(format) ||
                "wav".equals(format) ||
                "mpc".equals(format) ||
-               "mp+".equals(format) ||
-               "ape".equals(format) ||
+               "aif".equals(format) ||
+               "dsf".equals(format) ||
+               "aiff".equals(format) ||
+               "aifc".equals(format) ||
+               "flac".equals(format) ||
                "wma".equals(format);
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -361,7 +361,6 @@ public class JaudiotaggerParser extends MetaDataParser {
         String format = FilenameUtils.getExtension(file.getName()).toLowerCase();
 
         return "mp3".equals(format) ||
-               "mp4".equals(format) ||
                "m4a".equals(format) ||
                "m4b".equals(format) ||
                "m4p".equals(format) ||


### PR DESCRIPTION
_Jaudiotagger_ does *not* support `ape` or `mp+` while it *does* support `aif/aiff/aifc`, `mp4`, `m4p` and `dsf`. This patch changes the supported types accordingly (and gets rid of a load of error messages caused by _Jaudiotagger_ being fed formats it doesn't understand)

 [edit]

While it does indeed support `mp4` it does not seem to do so in a meaningful way; I removed this type from the list, use ffmpeg for this purpose