### PR TITLE
Change to new shuffle generator

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceImpl.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceImpl.java
@@ -50,9 +50,6 @@ public class SearchServiceImpl implements SearchService {
     @Autowired
     private SearchServiceUtilities util;
 
-    // TODO Should be changed to SecureRandom?
-    private final Random random = new Random(System.currentTimeMillis());
-
     @Override
     public SearchResult search(SearchCriteria criteria, List<MusicFolder> musicFolders,
             IndexType indexType) {
@@ -108,7 +105,7 @@ public class SearchServiceImpl implements SearchService {
 
         List<D> result = new ArrayList<>();
         while (!docs.isEmpty() && result.size() < count) {
-            int randomPos = random.nextInt(docs.size());
+            int randomPos = util.nextInt.apply(docs.size());
             Document document = searcher.doc(docs.get(randomPos));
             id2ListCallBack.accept(result, util.getId.apply(document));
             docs.remove(randomPos);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceUtilities.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceUtilities.java
@@ -31,13 +31,21 @@ import org.airsonic.player.service.MediaFileService;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.lucene.document.Document;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.springframework.util.ObjectUtils.isEmpty;
 
@@ -70,6 +78,45 @@ public class SearchServiceUtilities {
      */
     @Autowired
     private MediaFileService mediaFileService;
+
+    private static final Logger LOG = LoggerFactory.getLogger(SearchServiceUtilities.class);
+
+    private Random random;
+    
+    private static Random createSecureRandom(String algorithm) {
+        SecureRandom secureRandom = null;
+        try {
+            LOG.debug("{} is used to create a random list of songs.", algorithm);
+            secureRandom = SecureRandom.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            LOG.error("Usually unreachable.", e);
+        }
+        return secureRandom;
+    }
+
+    {
+
+        String algorithmNative = "NativePRNG";
+        String algorithmSHA = "SHA1PRNG";
+
+        List<String> algorithms = Arrays.asList(Security.getProviders()).stream()
+                .flatMap(p -> p.getServices().stream().filter(s -> "SecureRandom".equals(s.getType())))
+                .map(s -> s.getAlgorithm()).collect(Collectors.toList());
+
+        if (algorithms.contains(algorithmNative)) {
+            random = createSecureRandom(algorithmNative);
+        } else if (algorithms.contains(algorithmSHA)) {
+            random = createSecureRandom(algorithmSHA);
+        }
+
+        if (isEmpty(random)) {
+            random = new Random(System.currentTimeMillis());
+            LOG.debug("NativePRNG and SHA1PRNG cannot be used on this platform.");
+        }
+
+    }
+
+    public Function<Integer, Integer> nextInt = (range) -> random.nextInt(range);
 
     public final Function<Long, Integer> round = (i) -> {
         // return

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceUtilitiesTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceUtilitiesTestCase.java
@@ -1,0 +1,16 @@
+package org.airsonic.player.service.search;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class SearchServiceUtilitiesTestCase {
+
+    SearchServiceUtilities utilities = new SearchServiceUtilities();
+
+    @Test
+    public void testNextInt() {
+        assertNotNull(utilities.nextInt.apply(100));
+    }
+
+}


### PR DESCRIPTION

The algorithm will be updated so that the shuffle can be performed with more consideration for "variation".
For user, the phenomenon that the same album continues even though there are many songs is reduced.

The algorithm is determined at startup by the environment.
Linux is almost the strongest because it uses ``/dev/random``.
Displays the algorithm to use at startup.

### Linux

![image](https://user-images.githubusercontent.com/27724847/64976993-7dbe8f00-d8ed-11e9-950e-f4a63cea45c2.png)

### Windows

![image](https://user-images.githubusercontent.com/27724847/64977229-f6255000-d8ed-11e9-8a69-762f68d03028.png)

In environments where the new algorithm is not available, the same algorithm is used as before.

Generally, this is a random algorithm used when generating a cipher.
The speed does not change much.

For source code, the subclassing of SearchServiceImpl's utility functions is complete by this PR.

