### PR TITLE
Change integration tests from parallel to single forked mode

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -196,8 +196,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <parallel>all</parallel>
-                    <threadCount>2</threadCount>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
                     <includes>
                         <include>**/Parallel*IT.class</include>
                     </includes>


### PR DESCRIPTION
This is an attempt to make the Travis CI integration tests more reliable, and changes from parallel to single forking mode.
This is a temporary measure until cucumber-jvm-parallel-plugin (which is no longer supported) is ripped out (see #1240)

In my limited tests, no longer using parallel forking and 2 threads and instead going to single forking mode makes the integration tests about 2 minutes (12.5 vs 10.5m) slower.  But if that is the cost of fixing the unreliability of the tests, that's not that bad of a trade-off.