### PR TITLE
Upgrade jackson-* to 2.10.0.pr3 to fix CVE-2019-16335, CVE-2019-14540

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,17 +113,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.9</version>
+                <version>2.10.0.pr3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.9.3</version>
+                <version>2.10.0.pr3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.9</version>
+                <version>2.10.0.pr3</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
build failures due to [CVE-2019-16335](https://nvd.nist.gov/vuln/detail/CVE-2019-16335), [CVE-2019-14540](https://nvd.nist.gov/vuln/detail/CVE-2019-14540) - upgrading _jackson-*_ to 2.10.0.pr3 as a temporary fix. If this CVE does not affect _airsonic_ it should be added to `airsonic-main/cve-suppressed.xml`