### PR TITLE
Replace deprecated IOUtils.closeQuietly calls

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/CoverArtService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/CoverArtService.java
@@ -24,6 +24,7 @@ import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.service.LastFmService;
 import org.airsonic.player.service.MediaFileService;
 import org.airsonic.player.service.SecurityService;
+import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.config.RequestConfig;
@@ -147,8 +148,8 @@ public class CoverArtService {
                 }
             }
         } finally {
-            IOUtils.closeQuietly(input);
-            IOUtils.closeQuietly(output);
+            FileUtil.closeQuietly(input);
+            FileUtil.closeQuietly(output);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -24,6 +24,7 @@ import org.airsonic.player.dao.ArtistDao;
 import org.airsonic.player.domain.*;
 import org.airsonic.player.service.*;
 import org.airsonic.player.service.metadata.JaudiotaggerParser;
+import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -197,7 +198,7 @@ public class CoverArtController implements LastModified {
         try {
             IOUtils.copy(in, response.getOutputStream());
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
     }
 
@@ -214,7 +215,7 @@ public class CoverArtController implements LastModified {
             }
             ImageIO.write(image, "jpeg", response.getOutputStream());
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
     }
 
@@ -227,7 +228,7 @@ public class CoverArtController implements LastModified {
             response.setContentType(imageInputStreamWithType.getRight());
             IOUtils.copy(in, response.getOutputStream());
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
     }
 
@@ -255,13 +256,13 @@ public class CoverArtController implements LastModified {
                 } catch (Throwable x) {
                     // Delete corrupt (probably empty) thumbnail cache.
                     LOG.warn("Failed to create thumbnail for " + request, x);
-                    IOUtils.closeQuietly(out);
+                    FileUtil.closeQuietly(out);
                     cachedImage.delete();
                     throw new IOException("Failed to create thumbnail for " + request + ". " + x.getMessage());
 
                 } finally {
                     semaphore.release();
-                    IOUtils.closeQuietly(out);
+                    FileUtil.closeQuietly(out);
                 }
             } else {
 //                LOG.info("Cache HIT - " + request + " (" + size + ")");
@@ -389,7 +390,7 @@ public class CoverArtController implements LastModified {
                 } catch (Throwable x) {
                     LOG.warn("Failed to process cover art " + coverArt + ": " + x, x);
                 } finally {
-                    IOUtils.closeQuietly(in);
+                    FileUtil.closeQuietly(in);
                 }
             }
             return createAutoCover(size, size);
@@ -639,7 +640,7 @@ public class CoverArtController implements LastModified {
             } catch (Throwable x) {
                 LOG.warn("Failed to process cover art for " + mediaFile + ": " + x, x);
             } finally {
-                IOUtils.closeQuietly(in);
+                FileUtil.closeQuietly(in);
             }
             return createAutoCover(width, height);
         }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -26,7 +26,6 @@ import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.HttpRange;
 import org.airsonic.player.util.Util;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -308,7 +307,7 @@ public class DownloadController implements LastModified {
             }
         } finally {
             out.flush();
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
@@ -19,8 +19,8 @@
  */
 package org.airsonic.player.controller;
 
+import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.StringUtil;
-import org.apache.commons.io.IOUtils;
 import org.eclipse.persistence.jaxb.JAXBContext;
 import org.eclipse.persistence.jaxb.MarshallerProperties;
 import org.jdom2.Attribute;
@@ -104,7 +104,7 @@ public class JAXBWriter {
             Attribute version = document.getRootElement().getAttribute("version");
             return version.getValue();
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/ProxyController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/ProxyController.java
@@ -19,6 +19,7 @@
  */
 package org.airsonic.player.controller;
 
+import org.airsonic.player.util.FileUtil;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -36,7 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.InputStream;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.OK;
 
 /**
  * A proxy for external HTTP requests.
@@ -70,7 +71,7 @@ public class ProxyController  {
                 }
             }
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
         return null;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -26,10 +26,10 @@ import org.airsonic.player.io.ShoutCastOutputStream;
 import org.airsonic.player.security.JWTAuthenticationToken;
 import org.airsonic.player.service.*;
 import org.airsonic.player.service.sonos.SonosHelper;
+import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.HttpRange;
 import org.airsonic.player.util.StringUtil;
 import org.airsonic.player.util.Util;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -278,7 +278,7 @@ public class StreamController {
                 securityService.updateUserByteCounts(user, status.getBytesTransfered(), 0L, 0L);
                 statusService.removeStreamStatus(status);
             }
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
         return;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
@@ -27,11 +27,11 @@ import org.airsonic.player.service.SettingsService;
 import org.airsonic.player.service.StatusService;
 import org.airsonic.player.upload.MonitoredDiskFileItemFactory;
 import org.airsonic.player.upload.UploadListener;
+import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -202,8 +202,8 @@ public class UploadController {
                         LOG.info("Unzipped " + entryFile);
                         unzippedFiles.add(entryFile);
                     } finally {
-                        IOUtils.closeQuietly(inputStream);
-                        IOUtils.closeQuietly(outputStream);
+                        FileUtil.closeQuietly(inputStream);
+                        FileUtil.closeQuietly(outputStream);
                     }
                 }
             }

--- a/airsonic-main/src/main/java/org/airsonic/player/io/InputStreamReaderThread.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/InputStreamReaderThread.java
@@ -19,7 +19,7 @@
  */
 package org.airsonic.player.io;
 
-import org.apache.commons.io.IOUtils;
+import org.airsonic.player.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,8 +61,8 @@ public class InputStreamReaderThread extends Thread {
         } catch (IOException x) {
             // Intentionally ignored.
         } finally {
-            IOUtils.closeQuietly(reader);
-            IOUtils.closeQuietly(input);
+            FileUtil.closeQuietly(reader);
+            FileUtil.closeQuietly(input);
         }
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/io/TranscodeInputStream.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/TranscodeInputStream.java
@@ -19,6 +19,7 @@
  */
 package org.airsonic.player.io;
 
+import org.airsonic.player.util.FileUtil;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,8 +80,8 @@ public class TranscodeInputStream extends InputStream {
                     } catch (IOException x) {
                         // Intentionally ignored. Will happen if the remote player closes the stream.
                     } finally {
-                        IOUtils.closeQuietly(in);
-                        IOUtils.closeQuietly(processOutputStream);
+                        FileUtil.closeQuietly(in);
+                        FileUtil.closeQuietly(processOutputStream);
                     }
                 }
             }.start();
@@ -112,8 +113,8 @@ public class TranscodeInputStream extends InputStream {
      * @see InputStream#close()
      */
     public void close() throws IOException {
-        IOUtils.closeQuietly(processInputStream);
-        IOUtils.closeQuietly(processOutputStream);
+        FileUtil.closeQuietly(processInputStream);
+        FileUtil.closeQuietly(processOutputStream);
 
         if (process != null) {
             process.destroy();

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
@@ -23,7 +23,6 @@ import org.airsonic.player.domain.*;
 import org.airsonic.player.service.jukebox.AudioPlayer;
 import org.airsonic.player.service.jukebox.AudioPlayerFactory;
 import org.airsonic.player.util.FileUtil;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -125,7 +124,7 @@ public class JukeboxLegacySubsonicService implements AudioPlayer.Listener {
 
         } catch (Exception x) {
             LOG.error("Error in jukebox: " + x, x);
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/LastFmCache.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/LastFmCache.java
@@ -22,6 +22,7 @@ package org.airsonic.player.service;
 import de.umass.lastfm.cache.Cache;
 import de.umass.lastfm.cache.ExpirationPolicy;
 import de.umass.lastfm.cache.FileSystemCache;
+import org.airsonic.player.util.FileUtil;
 import org.apache.commons.io.IOUtils;
 
 import java.io.*;
@@ -66,7 +67,7 @@ public class LastFmCache extends Cache {
         } catch (Exception e) {
             return null;
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
     }
 
@@ -98,8 +99,8 @@ public class LastFmCache extends Cache {
         } catch (Exception e) {
             // we ignore the exception. if something went wrong we just don't cache it.
         } finally {
-            IOUtils.closeQuietly(xmlOut);
-            IOUtils.closeQuietly(metaOut);
+            FileUtil.closeQuietly(xmlOut);
+            FileUtil.closeQuietly(metaOut);
         }
     }
 
@@ -129,7 +130,7 @@ public class LastFmCache extends Cache {
         } catch (Exception e) {
             return false;
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlaylistService.java
@@ -30,10 +30,10 @@ import org.airsonic.player.domain.Playlist;
 import org.airsonic.player.domain.User;
 import org.airsonic.player.service.playlist.PlaylistExportHandler;
 import org.airsonic.player.service.playlist.PlaylistImportHandler;
+import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.Pair;
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -299,7 +299,7 @@ public class PlaylistService {
             importPlaylist(User.USERNAME_ADMIN, FilenameUtils.getBaseName(fileName), fileName, in, existingPlaylist);
             LOG.info("Auto-imported playlist " + file);
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -30,6 +30,7 @@ import org.airsonic.player.domain.PodcastStatus;
 import org.airsonic.player.service.metadata.MetaData;
 import org.airsonic.player.service.metadata.MetaDataParser;
 import org.airsonic.player.service.metadata.MetaDataParserFactory;
+import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.StringUtil;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -345,7 +346,7 @@ public class PodcastService {
             channel.setErrorMessage(getErrorMessage(x));
             podcastDao.updateChannel(channel);
         } finally {
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(in);
         }
 
         if (downloadEpisodes) {
@@ -384,8 +385,8 @@ public class PodcastService {
         } catch (Exception x) {
             LOG.warn("Failed to download cover art for podcast channel '" + channel.getTitle() + "': " + x, x);
         } finally {
-            IOUtils.closeQuietly(in);
-            IOUtils.closeQuietly(out);
+            FileUtil.closeQuietly(in);
+            FileUtil.closeQuietly(out);
         }
     }
 
@@ -600,14 +601,14 @@ public class PodcastService {
 
                 if (isEpisodeDeleted(episode)) {
                     LOG.info("Podcast " + episode.getUrl() + " was deleted. Aborting download.");
-                    IOUtils.closeQuietly(out);
+                    FileUtil.closeQuietly(out);
                     file.delete();
                 } else {
                     addMediaFileIdToEpisodes(Arrays.asList(episode));
                     episode.setBytesDownloaded(bytesDownloaded);
                     podcastDao.updateEpisode(episode);
                     LOG.info("Downloaded " + bytesDownloaded + " bytes from Podcast " + episode.getUrl());
-                    IOUtils.closeQuietly(out);
+                    FileUtil.closeQuietly(out);
                     updateTags(file, episode);
                     episode.setStatus(PodcastStatus.COMPLETED);
                     podcastDao.updateEpisode(episode);
@@ -620,8 +621,8 @@ public class PodcastService {
             episode.setErrorMessage(getErrorMessage(x));
             podcastDao.updateEpisode(episode);
         } finally {
-            IOUtils.closeQuietly(in);
-            IOUtils.closeQuietly(out);
+            FileUtil.closeQuietly(in);
+            FileUtil.closeQuietly(out);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/UPnPService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/UPnPService.java
@@ -22,7 +22,7 @@ package org.airsonic.player.service;
 import org.airsonic.player.service.upnp.ApacheUpnpServiceConfiguration;
 import org.airsonic.player.service.upnp.CustomContentDirectory;
 import org.airsonic.player.service.upnp.MSMediaReceiverRegistrarService;
-import org.apache.commons.io.IOUtils;
+import org.airsonic.player.util.FileUtil;
 import org.fourthline.cling.UpnpService;
 import org.fourthline.cling.UpnpServiceImpl;
 import org.fourthline.cling.binding.annotations.AnnotationLocalServiceBinder;
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 
-import java.io.*;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -159,7 +159,7 @@ public class UPnPService {
 
         InputStream in = getClass().getResourceAsStream("logo-512.png");
         Icon icon = new Icon("image/png", 512, 512, 32, "logo-512", in);
-        IOUtils.closeQuietly(in);
+        FileUtil.closeQuietly(in);
 
         LocalService<CustomContentDirectory> contentDirectoryservice = new AnnotationLocalServiceBinder().read(CustomContentDirectory.class);
         contentDirectoryservice.setManager(new DefaultServiceManager<CustomContentDirectory>(contentDirectoryservice) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
@@ -21,7 +21,7 @@ package org.airsonic.player.service;
 
 import com.jayway.jsonpath.JsonPath;
 import org.airsonic.player.domain.Version;
-import org.apache.commons.io.IOUtils;
+import org.airsonic.player.util.FileUtil;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
@@ -202,8 +202,8 @@ public class VersionService {
         } catch (IOException x) {
             return null;
         } finally {
-            IOUtils.closeQuietly(reader);
-            IOUtils.closeQuietly(in);
+            FileUtil.closeQuietly(reader);
+            FileUtil.closeQuietly(in);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/jukebox/AudioPlayer.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/jukebox/AudioPlayer.java
@@ -19,7 +19,7 @@
  */
 package org.airsonic.player.service.jukebox;
 
-import org.apache.commons.io.IOUtils;
+import org.airsonic.player.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,7 +114,7 @@ public class AudioPlayer {
         } catch (Throwable x) {
             LOG.warn("Failed to close player: " + x, x);
         }
-        IOUtils.closeQuietly(in);
+        FileUtil.closeQuietly(in);
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
@@ -20,7 +20,6 @@
 package org.airsonic.player.util;
 
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.*;
@@ -294,8 +293,8 @@ public final class StringUtil {
             return result.toArray(new String[result.size()]);
 
         } finally {
-            IOUtils.closeQuietly(in);
-            IOUtils.closeQuietly(reader);
+            FileUtil.closeQuietly(in);
+            FileUtil.closeQuietly(reader);
         }
     }
 


### PR DESCRIPTION
Use FileUtil.closeQuietly instead, since it's our reimplemented of this deprecated method.
This change was done automatically via IntelliJ IDEA.