### PR TITLE
Fix for alignment problem in General Settings page

### DIFF
--- a/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
+++ b/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
@@ -194,6 +194,7 @@ input, textarea, select {
     padding: 3px;
     border-radius: 3px;
     border: 1px solid lightgray;
+    vertical-align: middle;
 }
 
 input[type=submit], input[type=button] {


### PR DESCRIPTION
Making textareas vertical-align middle allows them to align with adjacent imgs.

Signed-off-by: Andrew V. Louis <13123840+avlouis@users.noreply.github.com>

---------------------------
This is a fix for #1199.
This is my first contribution, so critiques are appreciated.