### PR TITLE
Add discogs search link to main album page

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
@@ -245,21 +245,21 @@
 
     <c:if test="${not empty model.artist and not empty model.album}">
         <sub:url value="https://www.google.com/search" var="googleUrl" encoding="UTF-8">
-            <sub:param name="q" value="\"${model.artist}\" \"${model.album}\""/>
+            <sub:param name="q" value="\"${fn:escapeXml(model.artist)}\" \"${fn:escapeXml(model.album)}\""/>
         </sub:url>
         <sub:url value="https://en.wikipedia.org/wiki/Special:Search" var="wikipediaUrl" encoding="UTF-8">
-            <sub:param name="search" value="\"${model.album}\""/>
+            <sub:param name="search" value="\"${fn:escapeXml(model.album)}\""/>
             <sub:param name="go" value="Go"/>
         </sub:url>
-        <sub:url value="allmusic.view" var="allmusicUrl">
-            <sub:param name="album" value="${model.album}"/>
+        <sub:url value="https://www.allmusic.com/search/albums/%22${fn:escapeXml(model.artist)}%22+%22${fn:escapeXml(model.album)}%22" var="allmusicUrl">
         </sub:url>
+        
         <sub:url value="https://www.last.fm/search" var="lastFmUrl" encoding="UTF-8">
-            <sub:param name="q" value="\"${model.artist}\" \"${model.album}\""/>
+            <sub:param name="q" value="\"${fn:escapeXml(model.artist)}\" \"${fn:escapeXml(model.album)}\""/>
             <sub:param name="type" value="album"/>
         </sub:url>
         <sub:url value="https://www.discogs.com/search/" var="discogsUrl" encoding="UTF-8">
-            <sub:param name="q" value="\"${model.artist}\" \"${model.album}\""/>
+            <sub:param name="q" value="\"${fn:escapeXml(model.artist)}\" \"${fn:escapeXml(model.album)}\""/>
             <sub:param name="type" value="release"/>
         </sub:url>
         <span class="header"><fmt:message key="top.search"/> <a target="_blank" href="${googleUrl}">Google</a></span> |

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
@@ -258,10 +258,15 @@
             <sub:param name="q" value="\"${model.artist}\" \"${model.album}\""/>
             <sub:param name="type" value="album"/>
         </sub:url>
+        <sub:url value="https://www.discogs.com/search/" var="discogsUrl" encoding="UTF-8">
+            <sub:param name="q" value="\"${model.artist}\" \"${model.album}\""/>
+            <sub:param name="type" value="release"/>
+        </sub:url>
         <span class="header"><fmt:message key="top.search"/> <a target="_blank" href="${googleUrl}">Google</a></span> |
         <span class="header"><a target="_blank" rel="noopener noreferrer" href="${wikipediaUrl}">Wikipedia</a></span> |
         <span class="header"><a target="_blank" rel="noopener noreferrer" href="${allmusicUrl}">allmusic</a></span> |
         <span class="header"><a target="_blank" rel="noopener noreferrer" href="${lastFmUrl}">Last.fm</a></span> |
+        <span class="header"><a target="_blank" rel="noopener noreferrer" href="${discogsUrl}">Discogs</a></span> |
         <c:if test="${not empty model.musicBrainzReleaseId}">
           <sub:url value="https://musicbrainz.org/release/${model.musicBrainzReleaseId}" var="musicBrainzUrl" encoding="UTF-8">
           </sub:url>


### PR DESCRIPTION
Small change to close #586. 
I just added a link to search discogs for the album, under type "release." Discogs can be helpful for searching for physical copies of the album or additional info not included on other sites, as discussed in the issue.