### PR TITLE
Replace deprecated Date by Calendar

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
@@ -42,6 +42,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
@@ -174,5 +175,13 @@ public class JAXBWriter {
         GregorianCalendar c = new GregorianCalendar();
         c.setTime(date);
         return datatypeFactory.newXMLGregorianCalendar(c).normalize();
+    }
+
+    public XMLGregorianCalendar convertCalendar(Calendar calendar) {
+        if (calendar == null) {
+            return null;
+        }
+
+        return datatypeFactory.newXMLGregorianCalendar((GregorianCalendar)calendar).normalize();
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -53,6 +53,7 @@ import org.subsonic.restapi.PodcastStatus;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.datatype.XMLGregorianCalendar;
 
 import java.util.*;
 
@@ -164,13 +165,13 @@ public class SubsonicRESTController {
         request = wrapRequest(request);
         License license = new License();
 
-
         license.setEmail("airsonic@github.com");
         license.setValid(true);
-        Date farFuture = new Date();
-        farFuture.setYear(farFuture.getYear() + 100);
-        license.setLicenseExpires(jaxbWriter.convertDate(farFuture));
-        license.setTrialExpires(jaxbWriter.convertDate(farFuture));
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.YEAR, calendar.get(Calendar.YEAR) + 1900 + 100);
+        XMLGregorianCalendar georgianCalendar = jaxbWriter.convertCalendar(calendar);
+        license.setLicenseExpires(georgianCalendar);
+        license.setTrialExpires(georgianCalendar);
 
         Response res = createResponse();
         res.setLicense(license);

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -168,10 +168,10 @@ public class SubsonicRESTController {
         license.setEmail("airsonic@github.com");
         license.setValid(true);
         Calendar calendar = Calendar.getInstance();
-        calendar.set(Calendar.YEAR, calendar.get(Calendar.YEAR) + 1900 + 100);
-        XMLGregorianCalendar georgianCalendar = jaxbWriter.convertCalendar(calendar);
-        license.setLicenseExpires(georgianCalendar);
-        license.setTrialExpires(georgianCalendar);
+        calendar.add(Calendar.YEAR, 100);
+        XMLGregorianCalendar farFuture = jaxbWriter.convertCalendar(calendar);
+        license.setLicenseExpires(farFuture);
+        license.setTrialExpires(farFuture);
 
         Response res = createResponse();
         res.setLicense(license);


### PR DESCRIPTION
Apparently, Date.setYear and Date.getYear are
deprecated in favour of Calendar, since Java6!

Source: https://docs.oracle.com/javase/6/docs/api/java/util/Date.html
