### PR TITLE
Display file id and path in debug scanning logs

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -153,10 +153,10 @@ public class MediaFileService {
         if (useFastCache || (mediaFile.getVersion() >= MediaFileDao.VERSION
                 && !settingsService.isIgnoreFileTimestamps()
                 && mediaFile.getChanged().getTime() >= FileUtil.lastModified(mediaFile.getFile()))) {
-            LOG.debug("Detected unmodified file");
+            LOG.debug("Detected unmodified file (id {}, path {})", mediaFile.getId(), mediaFile.getPath());
             return mediaFile;
         }
-        LOG.debug("Updating database file from disk");
+        LOG.debug("Updating database file from disk (id {}, path {})", mediaFile.getId(), mediaFile.getPath());
         mediaFile = createMediaFile(mediaFile.getFile());
         mediaFileDao.createOrUpdateMediaFile(mediaFile);
         return mediaFile;


### PR DESCRIPTION
Why have 100s of lines with "Detected unmodified file" with no additional info if we're spammed with debug logs anyway? :smile: 

Plus this could be useful for debugging scanning issues along with the debug logger settings in https://github.com/airsonic/airsonic-docs/pull/77.