### PR TITLE
Release 10.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ matrix:
   include:
   - jdk: openjdk8
   - jdk: oraclejdk9
+    before_install:
+        # The OpenJDK9's CA bundle is outdated, so we're using the system's ones.
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
   - jdk: openjdk11
   - jdk: openjdk12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 # airsonic/airsonic
 # -->
 
+## v10.4.1 - ?
+
+### Fixes
+
+- Last song in a play queue no longer repeats (#1254)
+- Add database support for MariaDB (#1188)
+
+### Developer
+
+- Replace dead repository (teleal.org) with a new one (#1277)
+- Some dependencies updated to new minor versions in order to fix CVEs
+- Some backported changes to make tests pass more reliably
+
 ## v10.4.0 - 13 Jul 2019
 
 Fixes:

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.airsonic.player</groupId>
         <artifactId>airsonic</artifactId>
-        <version>10.4.0-RELEASE</version>
+        <version>10.4.1-RELEASE</version>
     </parent>
 
     <properties>

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -426,6 +426,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
             <!-- commons-configuration2 requires during runtime -->
             <scope>runtime</scope>
         </dependency>

--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -5,7 +5,7 @@
     <property name="binary_type" dbms="hsqldb" value="binary" />
     <property name="binary_type" value="blob" />
     <property name="curr_date_expr" value="current_timestamp" />
-    <property name="varchar_type" dbms="mysql" value="varchar(${mysqlVarcharLimit})" />
+    <property name="varchar_type" dbms="mariadb,mysql" value="varchar(${mysqlVarcharLimit})" />
     <property name="varchar_type" value="varchar" />
     <include file="legacy/legacy-changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.2/changelog.xml" relativeToChangelogFile="true"/>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -197,20 +197,16 @@
     }
 
     function createMediaElementPlayer() {
-
-        var player = $('#audioPlayer').get(0);
+        // Manually run MediaElement.js initialization.
+        //
+        // Warning: Bugs will happen if MediaElement.js is not initialized when
+        // we modify the media elements (e.g. adding event handlers). Running
+        // MediaElement.js's automatic initialization does not guarantee that
+        // (it depends on when we call createMediaElementPlayer at load time).
+        $('#audioPlayer').mediaelementplayer();
 
         // Once playback reaches the end, go to the next song, if any.
-        player.addEventListener("ended", onEnded);
-
-        // FIXME: Remove once https://github.com/mediaelement/mediaelement/issues/2650 is fixed.
-        //
-        // Once a media is loaded, we can start playback, but not before.
-        //
-        // Trying to start playback after a song has endred but before the
-        // 'canplay' event for the next song currently causes a race condition
-        // in the MediaElement.js player (4.2.10).
-        player.addEventListener("canplay", function() { player.play(); });
+        $('#audioPlayer').on("ended", onEnded);
     }
 
     function getPlayQueue() {
@@ -678,19 +674,8 @@
             player.currentTime = position || 0;
         }
 
-        // FIXME: Uncomment once https://github.com/mediaelement/mediaelement/issues/2650 is fixed.
-        //
-        // Calling 'player.play()' at this point may work by chance, but it's
-        // not guaranteed in the current MediaElement.js player (4.2.10).  See
-        // the 'createMediaElementPlayer()' function above.
-        //
-        // player.play();
-
-        // FIXME: Remove once https://github.com/mediaelement/mediaelement/issues/2650 is fixed.
-        //
-        // Instead, we're triggering a 'waiting' event so that the player shows
-        // a progress bar to indicate that it's loading the stream.
-        player.dispatchEvent(new Event("waiting"));
+        // Start playback immediately.
+        player.play();
     }
 
     function skip(index, position) {
@@ -851,7 +836,7 @@
                     <c:if test="${model.player.web}">
                         <td>
                             <div id="player" style="width:340px; height:40px">
-                                <audio id="audioPlayer" class="mejs__player" data-mejsoptions='{"alwaysShowControls": true, "enableKeyboard": false}' width="340px" height"40px" tabindex="-1" />
+                                <audio id="audioPlayer" data-mejsoptions='{"alwaysShowControls": true, "enableKeyboard": false}' width="340px" height"40px" tabindex="-1" />
                             </div>
                             <div id="castPlayer" style="display: none">
                                 <div style="float:left">

--- a/airsonic-sonos-api/pom.xml
+++ b/airsonic-sonos-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.airsonic.player</groupId>
         <artifactId>airsonic</artifactId>
-        <version>10.4.0-RELEASE</version>
+        <version>10.4.1-RELEASE</version>
     </parent>
 
     <dependencies>

--- a/install/docker/pom.xml
+++ b/install/docker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../pom.xml</relativePath>
         <artifactId>airsonic</artifactId>
-        <version>10.4.0-RELEASE</version>
+        <version>10.4.1-RELEASE</version>
         <groupId>org.airsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.airsonic.player</groupId>
             <artifactId>airsonic-main</artifactId>
-            <version>10.4.0-RELEASE</version>
+            <version>10.4.1-RELEASE</version>
             <type>war</type>
         </dependency>
     </dependencies>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.airsonic.player</groupId>
         <artifactId>airsonic</artifactId>
-        <version>10.4.0-RELEASE</version>
+        <version>10.4.1-RELEASE</version>
     </parent>
 
     <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -196,8 +196,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <parallel>all</parallel>
-                    <threadCount>2</threadCount>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
                     <includes>
                         <include>**/Parallel*IT.class</include>
                     </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.0</version>
+                        <configuration>
+                            <!-- #1186 Temporarily skip a test. -->
+                            <excludes>org.airsonic.player.service.search.*TestCase.java</excludes>
+                        </configuration>
                 </plugin>
                 <plugin>
                     <groupId>net.nicoulaj.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,17 +113,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.9</version>
+                <version>2.10.0.pr3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.9.3</version>
+                <version>2.10.0.pr3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.9</version>
+                <version>2.10.0.pr3</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.airsonic.player</groupId>
     <artifactId>airsonic</artifactId>
-    <version>10.4.0-RELEASE</version>
+    <version>10.4.1-RELEASE</version>
     <name>Airsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -28,19 +28,16 @@
             <url>file://${project.basedir}/../repo</url>
         </repository>
         <repository>
-            <id>java_net</id>
-            <name>download.java.net</name>
-            <url>https://download.java.net/maven/2/</url>
-        </repository>
-        <repository>
-            <id>teleal</id>
-            <name>teleal</name>
-            <url>http://teleal.org/m2</url>
-        </repository>
-        <repository>
             <id>jaudiotagger-repository</id>
             <url>https://dl.bintray.com/ijabz/maven</url>
         </repository>
+        <repository>
+          <id>4thline-repo</id>
+          <url>http://4thline.org/m2</url>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+      </repository>
     </repositories>
 
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <failOnDependencyWarning>true</failOnDependencyWarning>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cxf.version>3.3.1</cxf.version>
-        <jackson.version>2.9.9</jackson.version>
         <tomcat.version>8.5.42</tomcat.version>
     </properties>
 
@@ -114,17 +113,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
+                <version>2.9.9</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>2.9.9.3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>2.9.9</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.airsonic.player</groupId>
         <artifactId>airsonic</artifactId>
-        <version>10.4.0-RELEASE</version>
+        <version>10.4.1-RELEASE</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
This is for releasing 10.4.1, with two important user-visible bugfixes:
- Last song in a play queue no longer repeats (#1254)
- Add database support for MariaDB (#1188) (@muff1nman This is the commit you were thinking about?)

On the developer side, it also replaces a dead Maven repository from the dependency sources, which prevented 10.4.0 sources from being built as is on new machines with no cached packages (#1277).