### PR TITLE
Removed the auto-refresh feature

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/command/PersonalSettingsCommand.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/command/PersonalSettingsCommand.java
@@ -53,7 +53,6 @@ public class PersonalSettingsCommand {
     private boolean songNotificationEnabled;
     private boolean queueFollowingSongs;
     private boolean lastFmEnabled;
-    private int listReloadDelay;
     private int paginationSize;
     private String lastFmUsername;
     private String lastFmPassword;
@@ -232,14 +231,6 @@ public class PersonalSettingsCommand {
 
     public void setLastFmEnabled(boolean lastFmEnabled) {
         this.lastFmEnabled = lastFmEnabled;
-    }
-
-    public int getListReloadDelay() {
-        return listReloadDelay;
-    }
-
-    public void setListReloadDelay(int listReloadDelay) {
-        this.listReloadDelay = listReloadDelay;
     }
 
     public String getLastFmUsername() {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/HomeController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/HomeController.java
@@ -132,7 +132,6 @@ public class HomeController  {
         map.put("coverArtSize", CoverArtScheme.MEDIUM.getSize());
         map.put("listOffset", listOffset);
         map.put("musicFolder", selectedMusicFolder);
-        map.put("listReloadDelay", userSettings.getListReloadDelay());
 
         return new ModelAndView("home","model",map);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/IndexController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/IndexController.java
@@ -30,7 +30,6 @@ public class IndexController {
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("showRight", userSettings.isShowNowPlayingEnabled());
         map.put("autoHidePlayQueue", userSettings.isAutoHidePlayQueue());
-        map.put("listReloadDelay", userSettings.getListReloadDelay());
         map.put("keyboardShortcutsEnabled", userSettings.isKeyboardShortcutsEnabled());
         map.put("showSideBar", userSettings.isShowSideBar());
         map.put("brand", settingsService.getBrand());

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/PersonalSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/PersonalSettingsController.java
@@ -78,7 +78,6 @@ public class PersonalSettingsController  {
         command.setBetaVersionNotificationEnabled(userSettings.isBetaVersionNotificationEnabled());
         command.setSongNotificationEnabled(userSettings.isSongNotificationEnabled());
         command.setAutoHidePlayQueue(userSettings.isAutoHidePlayQueue());
-        command.setListReloadDelay(userSettings.getListReloadDelay());
         command.setKeyboardShortcutsEnabled(userSettings.isKeyboardShortcutsEnabled());
         command.setLastFmEnabled(userSettings.isLastFmEnabled());
         command.setLastFmUsername(userSettings.getLastFmUsername());
@@ -146,7 +145,6 @@ public class PersonalSettingsController  {
         settings.setBetaVersionNotificationEnabled(command.isBetaVersionNotificationEnabled());
         settings.setSongNotificationEnabled(command.isSongNotificationEnabled());
         settings.setAutoHidePlayQueue(command.isAutoHidePlayQueue());
-        settings.setListReloadDelay(command.getListReloadDelay());
         settings.setKeyboardShortcutsEnabled(command.isKeyboardShortcutsEnabled());
         settings.setLastFmEnabled(command.isLastFmEnabled());
         settings.setLastFmUsername(command.getLastFmUsername());

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
@@ -224,7 +224,7 @@ public class UserDao extends AbstractDao {
                 settings.getAvatarScheme().name(), settings.getSystemAvatarId(), settings.getChanged(),
                 settings.isShowArtistInfoEnabled(), settings.isAutoHidePlayQueue(),
                 settings.isViewAsList(), settings.getDefaultAlbumList().getId(), settings.isQueueFollowingSongs(),
-                settings.isShowSideBar(), settings.getListReloadDelay(), settings.isKeyboardShortcutsEnabled(),
+                settings.isShowSideBar(), 60 /* Unused listReloadDelay */, settings.isKeyboardShortcutsEnabled(),
                 settings.getPaginationSize());
     }
 
@@ -384,7 +384,7 @@ public class UserDao extends AbstractDao {
             settings.setDefaultAlbumList(AlbumListType.fromId(rs.getString(col++)));
             settings.setQueueFollowingSongs(rs.getBoolean(col++));
             settings.setShowSideBar(rs.getBoolean(col++));
-            settings.setListReloadDelay((Integer) rs.getObject(col++));
+            col++;  // Skip the now unused listReloadDelay
             settings.setKeyboardShortcutsEnabled(rs.getBoolean(col++));
             settings.setPaginationSize(rs.getInt(col++));
 

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/UserSettings.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/UserSettings.java
@@ -46,7 +46,6 @@ public class UserSettings {
     private Visibility mainVisibility = new Visibility();
     private Visibility playlistVisibility = new Visibility();
     private boolean lastFmEnabled;
-    private int listReloadDelay;
     private String lastFmUsername;
     private String lastFmPassword;
     private TranscodeScheme transcodeScheme = TranscodeScheme.OFF;
@@ -148,14 +147,6 @@ public class UserSettings {
 
     public void setLastFmEnabled(boolean lastFmEnabled) {
         this.lastFmEnabled = lastFmEnabled;
-    }
-
-    public int getListReloadDelay() {
-        return listReloadDelay;
-    }
-
-    public void setListReloadDelay(int listReloadDelay) {
-        this.listReloadDelay = listReloadDelay;
     }
 
     public String getLastFmUsername() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -1145,7 +1145,6 @@ public class SettingsService {
         settings.setQueueFollowingSongs(true);
         settings.setDefaultAlbumList(AlbumListType.RANDOM);
         settings.setLastFmEnabled(false);
-        settings.setListReloadDelay(60);
         settings.setLastFmUsername(null);
         settings.setLastFmPassword(null);
         settings.setChanged(new Date());

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_bg.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_bg.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=\u0423\u0432\u0435\u0434\u043E\u043C\u044F\u0432\u0430\u0439 \u043C\u0435 \u0437\u0430 \u043D\u043E\u0432\u0438 \u0432\u0435\u0440\u0441\u0438\u0438
 personalsettings.betaversionnotification=\u0423\u0432\u0435\u0434\u043E\u043C\u044F\u0432\u0430\u0439 \u043C\u0435 \u0437\u0430 \u043D\u043E\u0432\u0438 \u0431\u0435\u0442\u0430 \u0432\u0435\u0440\u0441\u0438\u0438
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=\u0420\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u0430\u0439 \u0442\u043E\u0432\u0430, \u043A\u043E\u0435\u0442\u043E \u0441\u043B\u0443\u0448\u0430\u043C \u0432 <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm \u043F\u043E\u0442\u0440\u0435\u0431\u0438\u0442\u0435\u043B

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ca.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ca.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Notifica'm sobre noves versions
 personalsettings.betaversionnotification=Notifica'm sobre noves versions beta
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Registrar el que estic reproduint a <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Nom d'usuari de Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_cs.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_cs.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Upozornit m\u011B na nov\u00E9 verze
 personalsettings.betaversionnotification=Upozornit m\u011B na nov\u00E9 betaverze
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Informovat <a href="http://last.fm/" target="_blank">Last.fm</a> o tom, co p\u0159ehr\u00E1v\u00E1m
 personalsettings.lastfmusername=U\u017Eivatel Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_da.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_da.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Advis\u00E9r mig om nye versioner
 personalsettings.betaversionnotification=Advis\u00E9r mig om nye beta-versioner
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Registrer hvad jeg spiller p\u00E5 <a href="http://last.fm/" target="_blank"> Last.fm </a>
 personalsettings.lastfmusername=Last.fm brugernavn

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_de.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_de.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Tastaturk\u00FCrzeln aktivieren
 personalsettings.finalversionnotification=Informiere mich \u00FCber neue Versionen
 personalsettings.betaversionnotification=Informiere mich \u00FCber neue Beta Versionen
 personalsettings.songnotification=Benachrichtigen Sie mich, wenn neue Songs gespielt werden (nicht von allen Browsern unterst\u00FCtzt)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Registriere was ich h\u00F6re bei <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm Benutzername

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_el.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_el.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=\u039D\u03B1 \u03B5\u03B9\u03B4\u03BF\u03C0\u03BF\u03B9\u03BF\u03CD\u03BC\u03B1\u03B9 \u03B3\u03B9\u03B1 \u03BA\u03B1\u03B9\u03BD\u03BF\u03CD\u03C1\u03B9\u03B5\u03C2 \u03B5\u03BA\u03B4\u03CC\u03C3\u03B5\u03B9\u03C2
 personalsettings.betaversionnotification=\u039D\u03B1 \u03B5\u03B9\u03B4\u03BF\u03C0\u03BF\u03B9\u03BF\u03CD\u03BC\u03B1\u03B9 \u03B3\u03B9\u03B1 \u03BA\u03B1\u03B9\u03BD\u03BF\u03CD\u03C1\u03B9\u03B5\u03C2 \u03B5\u03BA\u03B4\u03CC\u03C3\u03B5\u03B9\u03C2 beta
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=\u039A\u03B1\u03C4\u03B1\u03B3\u03C1\u03B1\u03C6\u03AE \u03C4\u03BF \u03C4\u03AF \u03B1\u03BA\u03BF\u03CD\u03C9 \u03C3\u03C4\u03BF <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm \u03CC\u03BD\u03BF\u03BC\u03B1 \u03C7\u03C1\u03AE\u03C3\u03C4\u03B7

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -362,7 +362,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Notify me of new versions
 personalsettings.betaversionnotification=Notify me of new beta versions
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Register what I'm playing at <a href="https://www.last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm username

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en_GB.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en_GB.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Notify me of new versions
 personalsettings.betaversionnotification=Notify me of new beta versions
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Register what I'm playing at <a href="https://www.last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm username

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_es.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_es.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Habilitar atajos del teclado
 personalsettings.finalversionnotification=Notificame sobre nuevas versiones
 personalsettings.betaversionnotification=Notificame sobre nuevas versiones beta
 personalsettings.songnotification=Notificarme cuando una nueva canci\u00F3n se reproduzca (no soportado por todos los navegadores)
-personalsettings.listreloaddelay=Retardo para la recarga de la lista del \u00E1lbum (en segundos, 0 lo deshabilita)
 personalsettings.paginationsize=N\u00FAmero de \u00E1lbumes/carpetas relacionados para mostrar inicialmente (0 deshabilita la paginaci\u00F3n de \u00E1lbumes)
 personalsettings.lastfmenabled=Registrar lo que estoy reproduciendo en <a href="https://www.last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Nombre de usuario de Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_et.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_et.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Uute versioonide v\u00e4ljastamisest teavita mind
 personalsettings.betaversionnotification=Uute Beta-versioonide v\u00e4ljastamisest teavita mind
 personalsettings.songnotification=Teavita mind, kui lugu vahetub (k\u00f5ik veebilehitsejad ei toeta seda)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Registreeri minu kuulatavate lugude loend portaali <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm\u00b4i kasutajanimi

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_fi.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_fi.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Ilmoita uudesta ohjelmaversiosta
 personalsettings.betaversionnotification=Ilmoita uudesta ohjelman beetta versiosta
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Rekister\u00F6i mit\u00E4 kuuntelen <a href="http://last.fm/" target="_blank">Last.fm-palveluun</a>
 personalsettings.lastfmusername=Last.fm k\u00E4ytt\u00E4j\u00E4tunnus

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_fr.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_fr.properties
@@ -362,7 +362,6 @@ personalsettings.keyboardshortcutsenabled=Activer les raccourcis clavier
 personalsettings.finalversionnotification=Me notifier les nouvelles versions
 personalsettings.betaversionnotification=Me notifier les nouvelles versions beta
 personalsettings.songnotification=Me notifier quand de nouveaux morceaux sont jou\u00e9s (non support\u00e9 par tous les explorateurs web)
-personalsettings.listreloaddelay=D\u00e9lai de rechargement de la liste d'album (secondes, 0: d\u00e9sactiv\u00e9)
 personalsettings.paginationsize=Nombre d'albums/r\u00e9pertoires associ\u00e9s \u00e0 afficher initialement (0 d\u00e9sactive la pagination des albums)
 personalsettings.lastfmenabled=Enregistrer ce que j'\u00e9coute sur <a href="https://www.last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Identifiant Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_is.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_is.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=L\u00E1ta mig vita af N\u00FDjum Uppf\u00E6rslum
 personalsettings.betaversionnotification=L\u00E1ta mig vita af Prufui \u00DAtg\u00E1fum
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Skr\u00E1 \u00C9g Er A\u00F0 Spila \u00C1 <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm Notandanafn

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_it.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_it.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Notificami nuove versioni
 personalsettings.betaversionnotification=Notificami nuove versioni beta
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Registra quello che sto ascoltando su <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Nome utente Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ja_JP.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ja_JP.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=\u65B0\u30D0\u30FC\u30B8\u30E7\u30F3\u3092\u901A\u77E5
 personalsettings.betaversionnotification=\u65B0\u3057\u3044\u30D9\u30FC\u30BF\u7248\u3092\u901A\u77E5
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=\u518D\u751F\u4E2D\u306E\u66F2\u3092 <a href="http://last.fm/" target="_blank">Last.fm</a> \u306B\u767B\u9332
 personalsettings.lastfmusername=Last.fm \u30E6\u30FC\u30B6\u540D

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ko.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ko.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=\uC0C8\uB85C\uC6B4 \uBC84\uC804(\uC548\uC815)\uC774 \uB098\uC624\uBA74 \uB098\uC5D0\uAC8C \uC54C\uB9BC
 personalsettings.betaversionnotification=\uC0C8\uB85C\uC6B4 \uBC84\uC804(\uBCA0\uD0C0)\uC774 \uB098\uC624\uBA74 \uB098\uC5D0\uAC8C \uC54C\uB9BC
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=\uB0B4\uAC00 \uAC10\uC0C1\uD558\uB294 \uB178\uB798\uB97C <a href="http://last.fm/" target="_blank">Last.fm</a> \uC5D0 \uB4F1\uB85D\uD558\uAE30
 personalsettings.lastfmusername=Last.fm \uC0AC\uC6A9\uC790 \uC774\uB984

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_mk.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_mk.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Notify me of new versions
 personalsettings.betaversionnotification=Notify me of new beta versions
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Register what I'm playing at <a href="https://www.last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm username

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_nl.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_nl.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Sneltoetsen inschakelen
 personalsettings.finalversionnotification=Melding bij nieuwe versies
 personalsettings.betaversionnotification=Melding bij nieuwe b\u00e8taversies
 personalsettings.songnotification=Melding bij afspelen van nieuwe nummers (word niet door alle webbrowsers ondersteund)
-personalsettings.listreloaddelay=Vertraging bij herladen van albumlijst (in seconden; 0=uitschakelen)
 personalsettings.paginationsize=Aantal te tonen gerelateerde albums/mappen (0=albumpaginering uitschakelen)
 personalsettings.lastfmenabled=Registreer wat ik afspeel op <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm-gebruikersnaam

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_nn.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_nn.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Vis melding om nye utg\u00E5ver
 personalsettings.betaversionnotification=Vis melding om nye beta-utg\u00E5ver
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Registrer kva eg spelar hos <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Brukarnamn for Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_no.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_no.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Vis melding om nye versjoner
 personalsettings.betaversionnotification=Vis melding om nye beta-versjoner
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Registrer hva jeg spiller hos <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Brukernavn for Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pl.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pl.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Powiadom mnie o nowej wersji
 personalsettings.betaversionnotification=Powiadom mnie o nowej beta wersji
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Rejestuj co odtwarzam na <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=U\u017Cytkownik Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Notifique-me sobre novas vers\u00F5es
 personalsettings.betaversionnotification=Notifique-me sobre novas vers\u00F5es beta
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Registar o que estou a ouvir no <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Utilizador Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt_BR.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt_BR.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Notify me of new versions
 personalsettings.betaversionnotification=Notify me of new beta versions
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Register what I'm playing at <a href="https://www.last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm username

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt_PT.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt_PT.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Notify me of new versions
 personalsettings.betaversionnotification=Notify me of new beta versions
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Register what I'm playing at <a href="https://www.last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm username

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ru.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ru.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=\u0421\u043E\u043E\u0431\u0449\u0430\u0442\u044C \u043E \u043D\u043E\u0432\u044B\u0445 \u0432\u0435\u0440\u0441\u0438\u044F\u0445
 personalsettings.betaversionnotification=\u0421\u043E\u043E\u0431\u0449\u0430\u0442\u044C \u043E \u043D\u043E\u0432\u044B\u0445 \u0431\u0435\u0442\u0430-\u0432\u0435\u0440\u0441\u0438\u044F\u0445
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=\u0420\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043E\u0432\u0430\u0442\u044C \u0447\u0442\u043E \u044F \u0441\u043B\u0443\u0448\u0430\u044E \u043D\u0430 <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm \u043B\u043E\u0433\u0438\u043D

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_sl.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_sl.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Obvesti me o novih razli\u010Dicah
 personalsettings.betaversionnotification=Obvesti me o novih beta razli\u010Dicah
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Zabele\u017Ei, kaj poslu\u0161am, na <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm uporabni\u0161ko ime

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_sv.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_sv.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Meddela om nya versioner
 personalsettings.betaversionnotification=Meddela om nya beta versioner
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Registrera vad jag spelar hos <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Last.fm anv\u00E4ndare

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_uk.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_uk.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=Notify me of new versions
 personalsettings.betaversionnotification=Notify me of new beta versions
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=Register what I'm playing at <a href="https://www.last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername=Ім'я користувача Last.fm

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_CN.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_CN.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=Enable keyboard shortcuts
 personalsettings.finalversionnotification=\u63D0\u793A\u65B0\u7248\u672C
 personalsettings.betaversionnotification=\u63D0\u793A\u65B0\u7684\u6D4B\u8BD5\u7248
 personalsettings.songnotification=Notify me when new songs are played (not supported by all web browsers)
-personalsettings.listreloaddelay=Delay when reloading album list(in seconds, 0 disables)
 personalsettings.paginationsize=Number of related albums/directories to show initially (0 disables album pagination)
 personalsettings.lastfmenabled=\u767B\u5F55 <a href="http://last.fm/" target="_blank">Last.fm</a>\u7684\u5E10\u53F7
 personalsettings.lastfmusername=Last.fm \u5E10\u53F7

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_TW.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_TW.properties
@@ -361,7 +361,6 @@ personalsettings.keyboardshortcutsenabled=\u555F\u7528\u9375\u76E4\u5FEB\u901F\u
 personalsettings.finalversionnotification=\u63D0\u9192\u6211\u65B0\u7248\u672C
 personalsettings.betaversionnotification=\u63D0\u9192\u6211\u65B0\u7684\u6E2C\u8A66\u7248
 personalsettings.songnotification=\u958B\u59CB\u64AD\u653E\u65B0\u6B4C\u6642\u63D0\u9192\u6211 (\u4E0D\u662F\u6240\u6709\u700F\u89BD\u5668\u90FD\u652F\u63F4)
-personalsettings.listreloaddelay=\u5C08\u8F2F\u6E05\u55AE\u5237\u65B0\u6642\u9593 (\u55AE\u4F4D\u70BA\u79D2\uFF0C0 \u4EE3\u8868\u505C\u7528)
 personalsettings.paginationsize=Number of initial related albums/directories to display (0 disables album pagination)
 personalsettings.lastfmenabled=\u5728 <a href="http://last.fm/" target="_blank">Last.fm</a> \u767B\u9304\u6211\u7684\u64AD\u653E\u52D5\u614B
 personalsettings.lastfmusername=Last.fm \u5E33\u865F

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
@@ -7,10 +7,6 @@
 
     <script type="text/javascript" language="javascript">
         function init() {
-            <c:if test="${model.listReloadDelay gt 0}">
-            setTimeout("refresh()", ${model.listReloadDelay * 1000});
-            </c:if>
-
             <c:if test="${not model.musicFoldersExist}">
             $().toastmessage("showNoticeToast", "<fmt:message key="top.missing"/>");
             </c:if>
@@ -18,10 +14,6 @@
             <c:if test="${model.isIndexBeingCreated}">
             $().toastmessage("showNoticeToast", "<fmt:message key="home.scan"/>");
             </c:if>
-        }
-
-        function refresh() {
-            top.main.location.href = top.main.location.href;
         }
 
         function playShuffle() {

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
@@ -186,10 +186,6 @@
 
     <table class="indent">
         <tr>
-            <td><fmt:message key="personalsettings.listreloaddelay"/></td>
-            <td><form:input path="listReloadDelay" size="24"/></td>
-        </tr>
-        <tr>
             <td><fmt:message key="personalsettings.paginationsize"/></td>
             <td><form:input path="paginationSize" size="24"/></td>
         </tr>

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
@@ -194,7 +194,6 @@ public class UserDaoTestCase extends DaoTestCaseBean2 {
         assertFalse("Error in getUserSettings().", userSettings.isNowPlayingAllowed());
         assertSame("Error in getUserSettings().", AvatarScheme.NONE, userSettings.getAvatarScheme());
         assertNull("Error in getUserSettings().", userSettings.getSystemAvatarId());
-        assertEquals("Error in getUserSettings().", 0, userSettings.getListReloadDelay());
         assertFalse("Error in getUserSettings().", userSettings.isKeyboardShortcutsEnabled());
         assertEquals("Error in getUserSettings().", 0, userSettings.getPaginationSize());
 
@@ -217,7 +216,6 @@ public class UserDaoTestCase extends DaoTestCaseBean2 {
         settings.setAvatarScheme(AvatarScheme.SYSTEM);
         settings.setSystemAvatarId(1);
         settings.setChanged(new Date(9412L));
-        settings.setListReloadDelay(60);
         settings.setKeyboardShortcutsEnabled(true);
         settings.setPaginationSize(120);
 
@@ -243,7 +241,6 @@ public class UserDaoTestCase extends DaoTestCaseBean2 {
         assertSame("Error in getUserSettings().", AvatarScheme.SYSTEM, userSettings.getAvatarScheme());
         assertEquals("Error in getUserSettings().", 1, userSettings.getSystemAvatarId().intValue());
         assertEquals("Error in getUserSettings().", new Date(9412L), userSettings.getChanged());
-        assertEquals("Error in getUserSettings().", 60, userSettings.getListReloadDelay());
         assertTrue("Error in getUserSettings().", userSettings.isKeyboardShortcutsEnabled());
         assertEquals("Error in getUserSettings().", 120, userSettings.getPaginationSize());
 


### PR DESCRIPTION
This feature just generated a lot of unnecessary traffic to the server and hurt usability because the page would refresh unexpectedly while a user was actively looking at content.  Fixes #1003, #1179, #729.

Did not remove the column for that setting in the user database (just coded around it), since that would lead to complications if needing to downgrade for some reason.