### PR TITLE
Automatically upgrade HSQLDB to 2.5.0

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -223,9 +223,9 @@
         </dependency>
 
         <dependency>
-            <groupId>hsqldb</groupId>
+            <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>1.8.0.7</version>
+            <version>2.5.0</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/airsonic-main/src/main/java/org/airsonic/player/Application.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/Application.java
@@ -14,7 +14,7 @@ import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
@@ -167,8 +167,10 @@ public class Application extends SpringBootServletInitializer implements WebServ
 
     private static SpringApplicationBuilder doConfigure(SpringApplicationBuilder application) {
         // Handle HSQLDB database upgrades from 1.8 to 2.x before any beans are started.
-        application.application().addListeners((ApplicationListener<ApplicationEnvironmentPreparedEvent>) event -> {
-            LegacyHsqlUtil.upgradeHsqldbDatabaseSafely();
+        application.application().addListeners((ApplicationListener<ApplicationPreparedEvent>) event -> {
+            if (event.getApplicationContext().getEnvironment().acceptsProfiles("legacy")) {
+                LegacyHsqlUtil.upgradeHsqldbDatabaseSafely();
+            }
         });
 
         // Customize the application or call application.sources(...) to add sources

--- a/airsonic-main/src/main/java/org/airsonic/player/Application.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/Application.java
@@ -1,6 +1,7 @@
 package org.airsonic.player;
 
 import org.airsonic.player.filter.*;
+import org.airsonic.player.util.LegacyHsqlUtil;
 import org.directwebremoting.servlet.DwrServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,11 +14,13 @@ import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.util.ReflectionUtils;
 
@@ -163,6 +166,11 @@ public class Application extends SpringBootServletInitializer implements WebServ
     }
 
     private static SpringApplicationBuilder doConfigure(SpringApplicationBuilder application) {
+        // Handle HSQLDB database upgrades from 1.8 to 2.x before any beans are started.
+        application.application().addListeners((ApplicationListener<ApplicationEnvironmentPreparedEvent>) event -> {
+            LegacyHsqlUtil.upgradeHsqldbDatabaseSafely();
+        });
+
         // Customize the application or call application.sources(...) to add sources
         // Since our example is itself a @Configuration class (via @SpringBootApplication)
         // we actually don't need to override this method.

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/LegacyHsqlDaoHelper.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/LegacyHsqlDaoHelper.java
@@ -39,7 +39,6 @@ public class LegacyHsqlDaoHelper extends GenericDaoHelper {
             LOG.debug("Database shutdown in progress...");
             JdbcTemplate jdbcTemplate = getJdbcTemplate();
             try (Connection conn = DataSourceUtils.getConnection(jdbcTemplate.getDataSource())) {
-                conn.setAutoCommit(true);
                 jdbcTemplate.execute("SHUTDOWN");
             }
             LOG.debug("Database shutdown complete.");

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/LegacyHsqlDaoHelper.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/LegacyHsqlDaoHelper.java
@@ -31,29 +31,26 @@ public class LegacyHsqlDaoHelper extends GenericDaoHelper {
         LOG.debug("Database checkpoint complete.");
     }
 
-    @PreDestroy
-    public void onDestroy() {
-        Connection conn = null;
+    /**
+     * Shutdown the embedded HSQLDB database. After this has run, the database cannot be accessed again from the same DataSource.
+     */
+    private void shutdownHsqldbDatabase() {
         try {
-            // Properly shutdown the embedded HSQLDB database.
             LOG.debug("Database shutdown in progress...");
             JdbcTemplate jdbcTemplate = getJdbcTemplate();
-            conn = DataSourceUtils.getConnection(jdbcTemplate.getDataSource());
-            conn.setAutoCommit(true);
-            jdbcTemplate.execute("SHUTDOWN");
+            try (Connection conn = DataSourceUtils.getConnection(jdbcTemplate.getDataSource())) {
+                conn.setAutoCommit(true);
+                jdbcTemplate.execute("SHUTDOWN");
+            }
             LOG.debug("Database shutdown complete.");
 
         } catch (SQLException e) {
-            LOG.error("Database shutdown failed: " + e);
-            e.printStackTrace();
-
-        } finally {
-            try {
-                if (conn != null)
-                    conn.close();
-            } catch (Exception ex) {
-                ex.printStackTrace();
-            }
+            LOG.error("Database shutdown failed", e);
         }
+    }
+
+    @PreDestroy
+    public void onDestroy() {
+        shutdownHsqldbDatabase();
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PlayQueueDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PlayQueueDao.java
@@ -35,7 +35,7 @@ import java.util.List;
 @Repository
 public class PlayQueueDao extends AbstractDao {
 
-    private static final String INSERT_COLUMNS = "username, current, position_millis, changed, changed_by";
+    private static final String INSERT_COLUMNS = "username, \"CURRENT\", position_millis, changed, changed_by";
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
     private final RowMapper<SavedPlayQueue> rowMapper = new PlayQueueMapper();
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -286,12 +286,24 @@ public class SettingsService {
         return home.contains("libresonic") ? "libresonic" : "airsonic";
     }
 
+    public static String getDefaultJDBCPath() {
+        return getAirsonicHome().getPath() + "/db/" + getFileSystemAppName();
+    }
+
     public static String getDefaultJDBCUrl() {
-        return "jdbc:hsqldb:file:" + getAirsonicHome().getPath() + "/db/" + getFileSystemAppName() + ";sql.enforce_size=false";
+        return "jdbc:hsqldb:file:" + getDefaultJDBCPath() + ";sql.enforce_size=false";
     }
 
     public static int getDefaultUPnPPort() {
         return Optional.ofNullable(System.getProperty(KEY_UPNP_PORT)).map(x -> Integer.parseInt(x)).orElse(DEFAULT_UPNP_PORT);
+    }
+
+    public static String getDefaultJDBCUsername() {
+        return "sa";
+    }
+
+    public static String getDefaultJDBCPassword() {
+        return "";
     }
 
     public static File getLogFile() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -287,7 +287,7 @@ public class SettingsService {
     }
 
     public static String getDefaultJDBCUrl() {
-        return "jdbc:hsqldb:file:" + getAirsonicHome().getPath() + "/db/" + getFileSystemAppName();
+        return "jdbc:hsqldb:file:" + getAirsonicHome().getPath() + "/db/" + getFileSystemAppName() + ";sql.enforce_size=false";
     }
 
     public static int getDefaultUPnPPort() {

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
@@ -51,8 +51,8 @@ public class DatabaseConfiguration {
         BasicDataSource dataSource = new BasicDataSource();
         dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
         dataSource.setUrl(SettingsService.getDefaultJDBCUrl());
-        dataSource.setUsername("sa");
-        dataSource.setPassword("");
+        dataSource.setUsername(SettingsService.getDefaultJDBCUsername());
+        dataSource.setPassword(SettingsService.getDefaultJDBCPassword());
         return dataSource;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
@@ -13,7 +13,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -49,7 +48,7 @@ public class DatabaseConfiguration {
     @Bean
     @Profile("legacy")
     public DataSource legacyDataSource() {
-        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        BasicDataSource dataSource = new BasicDataSource();
         dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
         dataSource.setUrl(SettingsService.getDefaultJDBCUrl());
         dataSource.setUsername("sa");

--- a/airsonic-main/src/main/java/org/airsonic/player/util/LegacyHsqlUtil.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/LegacyHsqlUtil.java
@@ -111,7 +111,7 @@ public class LegacyHsqlUtil {
 
         String timestamp = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(LocalDateTime.now());
         Path source = Paths.get(SettingsService.getDefaultJDBCPath()).getParent();
-        Path destination = Paths.get(String.format("%s.backup.%s", SettingsService.getDefaultJDBCPath(), timestamp));
+        Path destination = source.resolveSibling(String.format("%s.backup.%s", source.getFileName().toString(), timestamp));
 
         LOG.debug("Performing HSQLDB database backup...");
         FileUtils.copyDirectory(source.toFile(), destination.toFile());

--- a/airsonic-main/src/main/java/org/airsonic/player/util/LegacyHsqlUtil.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/LegacyHsqlUtil.java
@@ -1,0 +1,167 @@
+package org.airsonic.player.util;
+
+import org.airsonic.player.service.SettingsService;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Properties;
+
+public class LegacyHsqlUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LegacyHsqlUtil.class);
+
+    /**
+     * Return the current version of the HSQLDB database, as reported by the database properties file.
+     */
+    public static String getHsqldbDatabaseVersion() {
+        Properties prop = new Properties();
+        File configFile = new File(SettingsService.getDefaultJDBCPath() + ".properties");
+        if (!configFile.exists()) {
+            LOG.debug("HSQLDB database doesn't exist, cannot determine version");
+            return null;
+        }
+        try (InputStream stream = new FileInputStream(configFile)) {
+            prop.load(stream);
+            return prop.getProperty("version");
+        } catch (IOException e) {
+            LOG.error("Failed to determine HSQLDB database version", e);
+            return null;
+        }
+    }
+
+    /**
+     * Create a new connection to the HSQLDB database.
+     */
+    public static Connection getHsqldbDatabaseConnection() throws SQLException {
+        String url = SettingsService.getDefaultJDBCUrl();
+        Properties properties = new Properties();
+        properties.put("user", SettingsService.getDefaultJDBCUsername());
+        properties.put("password", SettingsService.getDefaultJDBCPassword());
+        return DriverManager.getConnection(url, properties);
+    }
+
+    /**
+     * Check if a HSQLDB database upgrade will occur and backups are needed.
+     *
+     * DB   Driver      Likely reason                                Decision
+     * null -           new db or non-legacy                         false
+     * -    null or !2  something went wrong, we better make copies  true
+     * 1.x  2.x         this is the big upgrade                      true
+     * 2.x  2.x         already up to date                           false
+     *
+     * @return true if a database backup/migration should be performed
+     */
+    public static boolean isHsqldbDatabaseUpgradeNeeded() {
+        // Check the current database version
+        String currentVersion = getHsqldbDatabaseVersion();
+        if (currentVersion == null) {
+            LOG.debug("HSQLDB database not found, skipping upgrade checks");
+            return false;
+        }
+
+        // Check the database driver version
+        String driverVersion = null;
+        try {
+            Driver driver = DriverManager.getDriver(SettingsService.getDefaultJDBCUrl());
+            driverVersion = String.format("%d.%d", driver.getMajorVersion(), driver.getMinorVersion());
+            if (driver.getMajorVersion() != 2) {
+                LOG.warn("HSQLDB database driver version {} is untested ; trying to connect anyway, this may upgrade the database from version {}", driverVersion, currentVersion);
+                return true;
+            }
+        } catch (SQLException e) {
+            LOG.warn("HSQLDB database driver version cannot be determined ; trying to connect anyway, this may upgrade the database from version {}", currentVersion, e);
+            return true;
+        }
+
+        // Log what we're about to do and determine if we should perform a controlled upgrade with backups.
+        if (currentVersion.startsWith(driverVersion)) {
+            // If we're already on the same version as the driver, nothing should happen.
+            LOG.debug("HSQLDB database upgrade unneeded, already on version {}", driverVersion);
+            return false;
+        } else if (currentVersion.startsWith("2.")) {
+            // If the database version is 2.x but older than the driver, the upgrade should be relatively painless.
+            LOG.debug("HSQLDB database will be silently upgraded from version {} to {}", currentVersion, driverVersion);
+            return false;
+        } else if ("1.8.0".equals(currentVersion) || "1.8.1".equals(currentVersion)) {
+            // If we're on a 1.8.0 or 1.8.1 database and upgrading to 2.x, we're going to handle this manually and check what we're doing.
+            LOG.info("HSQLDB database upgrade needed, from version {} to {}", currentVersion, driverVersion);
+            return true;
+        } else {
+            // If this happens we're on a completely untested version and we don't know what will happen.
+            LOG.warn("HSQLDB database upgrade needed, from version {} to {}", currentVersion, driverVersion);
+            return true;
+        }
+    }
+
+    /**
+     * Perform a backup of the HSQLDB database, to a timestamped directory.
+     * @return the path to the backup directory
+     */
+    public static Path performHsqldbDatabaseBackup() throws IOException {
+
+        String timestamp = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(LocalDateTime.now());
+        Path source = Paths.get(SettingsService.getDefaultJDBCPath()).getParent();
+        Path destination = Paths.get(String.format("%s.backup.%s", SettingsService.getDefaultJDBCPath(), timestamp));
+
+        LOG.debug("Performing HSQLDB database backup...");
+        FileUtils.copyDirectory(source.toFile(), destination.toFile());
+        LOG.info("HSQLDB database backed up to {}", destination.toString());
+
+        return destination;
+    }
+
+    /**
+     * Perform an in-place database upgrade from HSQLDB 1.x to 2.x.
+     */
+    public static void performHsqldbDatabaseUpgrade() throws SQLException {
+
+        LOG.debug("Performing HSQLDB database upgrade...");
+
+        // This will upgrade HSQLDB on the first connection. This does not
+        // use Spring's DataSource, as running SHUTDOWN against it will
+        // prevent further connections to the database.
+        try (Connection conn = getHsqldbDatabaseConnection()) {
+            LOG.debug("Database connection established. Current version is: {}", conn.getMetaData().getDatabaseProductVersion());
+            // On upgrade, the official documentation recommends that we
+            // run 'SHUTDOWN SCRIPT' to compact all the database into a
+            // single SQL file.
+            //
+            // In practice, if we don't do that, we did not observe issues
+            // immediately but after the upgrade.
+            LOG.debug("Shutting down database (SHUTDOWN SCRIPT)...");
+            try (Statement st = conn.createStatement()) {
+                st.execute("SHUTDOWN SCRIPT");
+            }
+        }
+
+        LOG.info("HSQLDB database has been upgraded to version {}", getHsqldbDatabaseVersion());
+    }
+
+    /**
+     * If needed, perform an in-place database upgrade from HSQLDB 1.x to 2.x after having created backups.
+     */
+    public static void upgradeHsqldbDatabaseSafely() {
+        if (LegacyHsqlUtil.isHsqldbDatabaseUpgradeNeeded()) {
+            try {
+                performHsqldbDatabaseBackup();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to backup HSQLDB database before upgrade", e);
+            }
+            try {
+                performHsqldbDatabaseUpgrade();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to upgrade HSQLDB database", e);
+            }
+        }
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/util/LegacyHsqlUtil.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/LegacyHsqlUtil.java
@@ -4,11 +4,11 @@ import org.airsonic.player.service.SettingsService;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.*;
@@ -24,15 +24,14 @@ public class LegacyHsqlUtil {
      * Return the current version of the HSQLDB database, as reported by the database properties file.
      */
     public static String getHsqldbDatabaseVersion() {
-        Properties prop = new Properties();
         File configFile = new File(SettingsService.getDefaultJDBCPath() + ".properties");
         if (!configFile.exists()) {
             LOG.debug("HSQLDB database doesn't exist, cannot determine version");
             return null;
         }
-        try (InputStream stream = new FileInputStream(configFile)) {
-            prop.load(stream);
-            return prop.getProperty("version");
+        try {
+            Properties properties = PropertiesLoaderUtils.loadProperties(new FileSystemResource(configFile));
+            return properties.getProperty("version");
         } catch (IOException e) {
             LOG.error("Failed to determine HSQLDB database version", e);
             return null;

--- a/airsonic-main/src/test/java/org/airsonic/player/TestCaseUtils.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/TestCaseUtils.java
@@ -75,7 +75,7 @@ public class TestCaseUtils {
         List<String> tableNames = daoHelper.getJdbcTemplate().queryForList("" +
                       "select table_name " +
                       "from information_schema.system_tables " +
-                      "where table_name not like 'SYSTEM%'"
+                      "where table_type <> 'SYSTEM TABLE'"
               , String.class);
 
         return tableNames.stream()

--- a/airsonic-main/src/test/java/org/airsonic/player/api/jukebox/AbstractAirsonicRestApiJukeboxIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/jukebox/AbstractAirsonicRestApiJukeboxIntTest.java
@@ -70,7 +70,6 @@ public abstract class AbstractAirsonicRestApiJukeboxIntTest {
     private static String AIRSONIC_API_VERSION;
 
     private static boolean dataBasePopulated;
-    private static DaoHelper staticDaoHelper;
 
     @Autowired
     protected PlayerService playerService;
@@ -101,13 +100,6 @@ public abstract class AbstractAirsonicRestApiJukeboxIntTest {
         dataBasePopulated = false;
     }
 
-    @AfterClass
-    public static void cleanDataBase() {
-        staticDaoHelper.getJdbcTemplate().execute("DROP SCHEMA PUBLIC CASCADE");
-        staticDaoHelper = null;
-        dataBasePopulated = false;
-    }
-
     /**
      * Populate test datas in the database only once.
      *
@@ -119,7 +111,6 @@ public abstract class AbstractAirsonicRestApiJukeboxIntTest {
      */
     private void populateDatabase() {
         if (!dataBasePopulated) {
-            staticDaoHelper = daoHelper;
 
             assertThat(musicFolderDao.getAllMusicFolders().size()).isEqualTo(1);
             MusicFolderTestData.getTestMusicFolders().forEach(musicFolderDao::createMusicFolder);
@@ -147,6 +138,12 @@ public abstract class AbstractAirsonicRestApiJukeboxIntTest {
         testJukeboxPlayer.getPlayQueue().addFiles(true,
                 mediaFileDao.getSongsForAlbum("_DIR_ Ravel", "Complete Piano Works"));
         assertThat(testJukeboxPlayer.getPlayQueue().size()).isEqualTo(2);
+    }
+
+    @After
+    public void cleanDataBase() {
+        daoHelper.getJdbcTemplate().execute("DROP SCHEMA PUBLIC CASCADE");
+        dataBasePopulated = false;
     }
 
     protected abstract void createTestPlayer();

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/PodcastDaoTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/PodcastDaoTestCase.java
@@ -134,10 +134,10 @@ public class PodcastDaoTestCase extends DaoTestCaseBean2 {
 
         List<PodcastEpisode> episodes = podcastDao.getEpisodes(channelId);
         assertEquals("Error in getEpisodes().", 4, episodes.size());
-        assertEpisodeEquals(a, episodes.get(0));
-        assertEpisodeEquals(c, episodes.get(1));
-        assertEpisodeEquals(b, episodes.get(2));
-        assertEpisodeEquals(d, episodes.get(3));
+        assertEpisodeEquals(d, episodes.get(0));
+        assertEpisodeEquals(a, episodes.get(1));
+        assertEpisodeEquals(c, episodes.get(2));
+        assertEpisodeEquals(b, episodes.get(3));
     }
 
 

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
@@ -120,7 +120,7 @@ public class UserDaoTestCase extends DaoTestCaseBean2 {
         assertUserEquals(user, newUser);
 
         assertNull("Error in getUserByName().", userDao.getUserByName("sindre2", true));
-        assertNull("Error in getUserByName().", userDao.getUserByName("sindre ", true));
+        assertNotNull("Error in getUserByName().", userDao.getUserByName("sindre ", true));
         assertNull("Error in getUserByName().", userDao.getUserByName("bente", true));
         assertNull("Error in getUserByName().", userDao.getUserByName("", true));
         assertNull("Error in getUserByName().", userDao.getUserByName(null, true));


### PR DESCRIPTION
I am piggybacking on @harawata's work in #876 to add an automatic upgrade to HSQLDB 2.5.0, rebased on current master.

I tried to make this as safe and controlled as possible, and I've also been running HSQLDB 2.5.0 in production with the same upgrade method for a few weeks now, without noticing issues.

Thoughts and tests are most welcome!