### PR TITLE
Allow previous Liquibase migration checksums for MariaDB

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/6.3/add-player-mixer.xml
+++ b/airsonic-main/src/main/resources/liquibase/6.3/add-player-mixer.xml
@@ -3,6 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="add-player-mixer_001" author="biconou">
+        <validCheckSum>8:f3bc74192812dcd68bcf8e5945f5a2ac</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="player" columnName="mixer" />

--- a/airsonic-main/src/main/resources/liquibase/6.4/add-album-mb-release-id.xml
+++ b/airsonic-main/src/main/resources/liquibase/6.4/add-album-mb-release-id.xml
@@ -3,6 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="add-album-mb-release-id" author="fxthomas">
+        <validCheckSum>8:554b1dab1d0ae6808830d870acf83046</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="album" columnName="mb_release_id" />

--- a/airsonic-main/src/main/resources/liquibase/6.4/add-media-file-mb-release-id.xml
+++ b/airsonic-main/src/main/resources/liquibase/6.4/add-media-file-mb-release-id.xml
@@ -3,6 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="add-media-file-mb-release-id" author="fxthomas">
+        <validCheckSum>8:fd01642a58f1fae9d908253d455e2255</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="media_file" columnName="mb_release_id" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema25.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema25.xml
@@ -30,6 +30,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema25_003" author="muff1nman">
+        <validCheckSum>8:f360471c71fa278a72aeb0ef8b3792ee</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="role" />
@@ -68,6 +69,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema25_004" author="muff1nman">
+        <validCheckSum>8:72e07b169e23067bd89ea458ff58fa48</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="user" />
@@ -90,6 +92,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema25_005" author="muff1nman">
+        <validCheckSum>8:4d92e7c97abc6f197f1236b0353ec2f7</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="user_role" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema26.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema26.xml
@@ -46,6 +46,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema26_003" author="muff1nman">
+        <validCheckSum>8:0c6447f4d1ccad4b86d908f9533df044</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="music_file_info" />
@@ -71,6 +72,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema26_004" author="muff1nman">
+        <validCheckSum>8:d9c3069bd0ebe8f33546115abdf1eb98</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="internet_radio" />
@@ -96,6 +98,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema26_005" author="muff1nman">
+        <validCheckSum>8:c53234c8f3594f463f5a929bb769112b</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="player" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema28.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema28.xml
@@ -16,6 +16,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema28_002" author="muff1nman">
+        <validCheckSum>8:df10cf4177190084441bc819d0a1e1c3</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="user_settings" />
@@ -99,6 +100,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema28_003" author="muff1nman">
+        <validCheckSum>8:22047927537571b66b940c3da4c522ee</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="transcoding" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema29.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema29.xml
@@ -16,6 +16,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema29_002" author="muff1nman">
+        <validCheckSum>8:fe1e8eafd7b3d08d810350d9a02c0f7b</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="user_rating" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema30.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema30.xml
@@ -16,6 +16,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema30_002" author="muff1nman">
+        <validCheckSum>8:0d052a6db950c7dbe1e88c8b6d0fde93</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="user_settings" columnName="last_fm_enabled" />
@@ -30,6 +31,7 @@
         </addColumn>
     </changeSet>
     <changeSet id="schema30_003" author="muff1nman">
+        <validCheckSum>8:d7dde2aca814346c586b547d7f3793e4</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="user_settings" columnName="transcode_scheme" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema32.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema32.xml
@@ -40,6 +40,7 @@
         </addColumn>
     </changeSet>
     <changeSet id="schema32_004" author="muff1nman">
+        <validCheckSum>8:8f6db2abc741f08aab64771fc1064c03</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="podcast_channel" />
@@ -64,6 +65,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema32_005" author="muff1nman">
+        <validCheckSum>8:95f9f9399c94a8672b6d5102ba2b0a80</validCheckSum>
         <validCheckSum>7:0d4fbe2adcca829c14d12a5b1a8229c5</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema35.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema35.xml
@@ -60,6 +60,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_005" author="muff1nman">
+        <validCheckSum>8:d428266eb794ae2f1361a6eec0f67672</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="system_avatar" />
@@ -91,6 +92,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_006" author="muff1nman">
+        <validCheckSum>8:60a4f99dea63d7813457a1b8f981f763</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="custom_avatar" />
@@ -125,6 +127,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_007" author="muff1nman">
+        <validCheckSum>8:653b5e40160877def2fe855b03f8ed42</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="user_settings" columnName="avatar_scheme" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema36.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema36.xml
@@ -16,6 +16,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema36_002" author="muff1nman">
+        <validCheckSum>8:b32e656eb1338a3ecaeec3cfe3c2b8c3</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="player" columnName="technology" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema38.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema38.xml
@@ -16,6 +16,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema38_002" author="muff1nman">
+        <validCheckSum>8:b667a345c9c60defe5a1b117f062c601</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="player" columnName="client_id" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema43.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema43.xml
@@ -118,6 +118,7 @@
         <rollback/>
     </changeSet>
     <changeSet id="schema43_003" author="muff1nman">
+        <validCheckSum>8:8ecc02a5ec4edb410a8babd0a8245216</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="user" columnName="email" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema45.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema45.xml
@@ -31,6 +31,7 @@
         <rollback />
     </changeSet>
     <changeSet id="schema45_003" author="muff1nman">
+        <validCheckSum>8:958f3a4e916720a8867885a2cf940d54</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="share" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema46.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema46.xml
@@ -16,6 +16,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema46_002" author="muff1nman">
+        <validCheckSum>8:a06ad5c377b5e13418ff69d33c6dc496</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="transcoding2" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema47.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema47.xml
@@ -16,6 +16,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema47_002" author="muff1nman">
+        <validCheckSum>8:6a093828880a904bd57feebc0c01ebd1</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="media_file" />
@@ -116,6 +117,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema47_003" author="muff1nman">
+        <validCheckSum>8:6e1ae92177617c5dad56d1ba85b241c0</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="artist" />
@@ -153,6 +155,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema47_004" author="muff1nman">
+        <validCheckSum>8:024d07d67c14a4c993d0cb124396c99c</validCheckSum>
         <validCheckSum>7:a3a788d87fd58508ecb4acac39e255c6</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
@@ -246,6 +249,7 @@
         </createIndex>
     </changeSet>
     <changeSet id="schema47_006" author="muff1nman">
+        <validCheckSum>8:2483df97b4b9984bd6ab324d837dcfcb</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="starred_media_file" />
@@ -277,6 +281,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema47_007" author="muff1nman">
+        <validCheckSum>8:32fc5e9da67a1547e7ef41241f9d198c</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="starred_album" />
@@ -308,6 +313,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema47_008" author="muff1nman">
+        <validCheckSum>8:f0c5210bccdb697dda5ab5c67f7cfe8b</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="starred_artist" />
@@ -339,6 +345,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema47_009" author="muff1nman">
+        <validCheckSum>8:d23ef0e36774d376d3893c4e4f77fc08</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="playlist" />
@@ -376,6 +383,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema47_010" author="muff1nman">
+        <validCheckSum>8:d284dccefde5e604a9bd4e736484fc80</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="playlist" columnName="imported_from" />
@@ -410,6 +418,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema47_012" author="muff1nman">
+        <validCheckSum>8:15f0f633935a0478e63be5544ac0adcb</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="playlist_user" />
@@ -432,6 +441,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema47_013" author="muff1nman">
+        <validCheckSum>8:9c7f948604127f8800ef527181bc4f59</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="bookmark" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema49.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema49.xml
@@ -26,6 +26,7 @@
         </addColumn>
     </changeSet>
     <changeSet id="schema49_003" author="muff1nman">
+        <validCheckSum>8:48810c74f102adade1af439589febc11</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="album" columnName="genre" />
@@ -36,6 +37,7 @@
         </addColumn>
     </changeSet>
     <changeSet id="schema49_004" author="muff1nman">
+        <validCheckSum>8:7b001d801628d7030007fe2d288adf6b</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="genre" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema52.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema52.xml
@@ -16,6 +16,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema52_002" author="muff1nman">
+        <validCheckSum>8:9eab62bc3d9cba6a9cfdbc58110a7df8</validCheckSum>
         <validCheckSum>7:8fde86035edbca443a54b1861ae70819</validCheckSum>
         <validCheckSum>7:e7e0f04cd4691ec2b5d955b449e0154b</validCheckSum>
         <preConditions onFail="MARK_RAN">
@@ -53,6 +54,7 @@
         </addColumn>
     </changeSet>
     <changeSet id="schema52_004" author="muff1nman">
+        <validCheckSum>8:a23c4e58cf64a1a76cb2c990342a4890</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="play_queue" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema53.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema53.xml
@@ -47,6 +47,7 @@
         </createIndex>
     </changeSet>
     <changeSet id="schema53_003" author="muff1nman">
+        <validCheckSum>8:354ba24098a5afe59761b39a36060298</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="user_settings" columnName="default_album_list" />
@@ -71,6 +72,7 @@
         </addColumn>
     </changeSet>
     <changeSet id="schema53_005" author="muff1nman">
+        <validCheckSum>8:a7e207e75eb9fbe25c2f911e89a26f21</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="podcast_channel" columnName="image_url" />


### PR DESCRIPTION
If someone was using MariaDB before #1188, they were probably doing so by using the MySQL JDBC driver to pass the migration (which had the proper workarounds in place for some column types).

This commit assumes that the migrations done that way were valid and produced the same result as running the MariaDB migrations after #1188.

This should fix #1333.