### PR TITLE
Additions to gitignore for static analysis plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,12 @@ local.properties
 # Eclipse Core
 .project
 
+# m2e-code-quality Eclipse IDE plugin temporary configuration files for Eclipse CS Checkstyle / PMD / SpotBugs Plug-Ins
+.checkstyle
+.pmd
+.pmdruleset.xml
+.fbExcludeFilterFile
+
 # Intellij
 *.iml
 .idea


### PR DESCRIPTION
Adds m2e exclusions for those who use Eclipse