### PR TITLE
Add some space below album list

### DIFF
--- a/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
+++ b/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
@@ -155,6 +155,7 @@ body {
     padding:0;
     border:0;
     margin:0.75em;
+    padding-bottom: 5em;
     font-family: Verdana, Tahoma, Geneva, arial, sans-serif;
     font-size: 10.5pt;
     line-height: 1.5em;


### PR DESCRIPTION
Trying to click "more" in "Random" album view, or ">" next to"Albums X-X" in "Recently added" quite often raises up play queue which pops over and hides the links. Adding a few em's of space below makes sure play queue don't accidentally pop up.