### PR TITLE
Added refresh link to all home navigation types

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
@@ -16,6 +16,10 @@
             </c:if>
         }
 
+        function refresh() {
+            top.main.location.href = top.main.location.href;
+        }
+
         function playShuffle() {
             top.playQueue.onPlayShuffle('${model.listType}', ${model.listOffset}, ${model.listSize}, '${model.genre}', '${model.decade}')
         }

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/homePager.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/homePager.jsp
@@ -12,37 +12,28 @@
                 </div>
             </td>
         </c:if>
-        <c:choose>
-            <c:when test="${model.listType eq 'random'}">
-                <td style="padding-left: 2em;">
-                    <a href="home.view?listType=random">
-                        <img src="<spring:theme code="refreshImage"/>" alt="Refresh" style="height:16px;">
-                        <fmt:message key="common.refresh"/>
-                    </a>
-                </td>
-            </c:when>
-            <c:otherwise>
-                <sub:url value="home.view" var="previousUrl">
-                    <sub:param name="listType" value="${model.listType}"/>
-                    <sub:param name="listOffset" value="${model.listOffset - model.listSize}"/>
-                    <sub:param name="genre" value="${model.genre}"/>
-                    <sub:param name="decade" value="${model.decade}"/>
-                </sub:url>
-                <sub:url value="home.view" var="nextUrl">
-                    <sub:param name="listType" value="${model.listType}"/>
-                    <sub:param name="listOffset" value="${model.listOffset + model.listSize}"/>
-                    <sub:param name="genre" value="${model.genre}"/>
-                    <sub:param name="decade" value="${model.decade}"/>
-                </sub:url>
 
-                <c:if test="${fn:length(model.albums) gt 0}">
-                    <td style="padding-right:0.5em">
-                        <fmt:message key="home.albums">
-                            <fmt:param value="${model.listOffset + 1}"/>
-                            <fmt:param value="${model.listOffset + fn:length(model.albums)}"/>
-                        </fmt:message>
-                    </td>
-                </c:if>
+        <c:if test="${model.listType ne 'random'}">
+            <sub:url value="home.view" var="previousUrl">
+                <sub:param name="listType" value="${model.listType}"/>
+                <sub:param name="listOffset" value="${model.listOffset - model.listSize}"/>
+                <sub:param name="genre" value="${model.genre}"/>
+                <sub:param name="decade" value="${model.decade}"/>
+            </sub:url>
+            <sub:url value="home.view" var="nextUrl">
+                <sub:param name="listType" value="${model.listType}"/>
+                <sub:param name="listOffset" value="${model.listOffset + model.listSize}"/>
+                <sub:param name="genre" value="${model.genre}"/>
+                <sub:param name="decade" value="${model.decade}"/>
+            </sub:url>
+
+            <c:if test="${fn:length(model.albums) gt 0}">
+                <td style="padding-right:0.5em">
+                    <fmt:message key="home.albums">
+                        <fmt:param value="${model.listOffset + 1}"/>
+                        <fmt:param value="${model.listOffset + fn:length(model.albums)}"/>
+                    </fmt:message>
+                </td>
 
                 <c:if test="${model.listOffset gt 0}">
                     <td><a href="${previousUrl}"><img src="<spring:theme code='backImage'/>" alt=""></a></td>
@@ -51,37 +42,46 @@
                 <c:if test="${fn:length(model.albums) eq model.listSize}">
                     <td><a href="${nextUrl}"><img src="<spring:theme code='forwardImage'/>" alt=""></a></td>
                 </c:if>
+                <td style="padding-right: 2em">
+                </td>
+            </c:if>
 
-                <c:if test="${model.listType eq 'decade'}">
-                    <td style="padding-left: 2em">
-                        <fmt:message key="home.decade.text"/>
-                    </td>
-                    <td>
-                        <select name="decade" onchange="location='home.view?listType=${model.listType}&amp;decade=' + options[selectedIndex].value">
-                            <c:forEach items="${model.decades}" var="decade">
-                                <option
-                                ${decade eq model.decade ? "selected" : ""} value="${decade}">${decade}</option>
-                            </c:forEach>
-                        </select>
-                    </td>
-                </c:if>
-                <c:if test="${model.listType eq 'genre'}">
-                    <td style="padding-left: 2em">
-                        <fmt:message key="home.genre.text"/>
-                    </td>
-                    <td>
-                        <select name="genre" onchange="location='home.view?listType=${model.listType}&amp;genre=' + encodeURIComponent(options[selectedIndex].value)">
-                            <c:forEach items="${model.genres}" var="genre">
-                                <option ${genre.name eq model.genre ? "selected" : ""} value="${genre.name}">${genre.name} (${genre.albumCount})</option>
-                            </c:forEach>
-                        </select>
-                    </td>
-                </c:if>
-            </c:otherwise>
-        </c:choose>
+            <c:if test="${model.listType eq 'decade'}">
+                <td>
+                    <fmt:message key="home.decade.text"/>
+                </td>
+                <td style="padding-right: 2em">
+                    <select name="decade" onchange="location='home.view?listType=${model.listType}&amp;decade=' + options[selectedIndex].value">
+                        <c:forEach items="${model.decades}" var="decade">
+                            <option
+                            ${decade eq model.decade ? "selected" : ""} value="${decade}">${decade}</option>
+                        </c:forEach>
+                    </select>
+                </td>
+            </c:if>
+            <c:if test="${model.listType eq 'genre'}">
+                <td>
+                    <fmt:message key="home.genre.text"/>
+                </td>
+                <td style="padding-right: 2em">
+                    <select name="genre" onchange="location='home.view?listType=${model.listType}&amp;genre=' + encodeURIComponent(options[selectedIndex].value)">
+                        <c:forEach items="${model.genres}" var="genre">
+                            <option ${genre.name eq model.genre ? "selected" : ""} value="${genre.name}">${genre.name} (${genre.albumCount})</option>
+                        </c:forEach>
+                    </select>
+                </td>
+            </c:if>
+        </c:if>
+
+        <td style="padding-right: 2em;">
+            <a href="javascript:refresh()">
+                <img src="<spring:theme code='refreshImage'/>" alt="Refresh" style="height:16px;">
+                <fmt:message key="common.refresh"/>
+            </a>
+        </td>
 
         <c:if test="${not empty model.albums}">
-            <td style="padding-left: 2em">
+            <td>
                 <a href="javascript:playShuffle()">
                   <img src="<spring:theme code='shuffleImage'/>" alt="Shuffle" style="height:16px;">
                   <fmt:message key="home.shuffle"/>


### PR DESCRIPTION
Per the suggestion in https://github.com/airsonic/airsonic/pull/1339#issuecomment-552224799 -

This adds a refresh link to all homePager.jsp browse methods in a
consistent place, so that users can easily refresh the proper frame
without causing a whole page refresh that would interrupt the web
player.
This is a follow-on to #1339 which removed the auto-refresh feature.
A side effect of this cleanup was to change all spacing between sets
of elements to a standard 2em to the right which made the layout
less convoluted.