### PR TITLE
Fix playback not starting after adding tracks to an empty play queue

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -532,6 +532,16 @@
             $("#empty").hide();
         }
 
+        // On the web player, the play button is handled by MEJS and does
+        // nothing if a first song hasn't been loaded.
+        <c:if test="${model.player.web}">
+        var player = $('#audioPlayer').get(0);
+        if (songs.length > 0 && (!player.src || !currentStreamUrl)) {
+            player.src = songs[0].streamUrl;
+            currentStreamUrl = songs[0].streamUrl;
+        }
+        </c:if>
+
         // Delete all the rows except for the "pattern" row
         dwr.util.removeAllRows("playlistBody", { filter:function(tr) {
             return (tr.id != "pattern");


### PR DESCRIPTION
Should fix #1407. To reproduce:

* Start Airsonic 10.5.0.
* Empty the play queue.
* Click on the "+" button on an album.
* Click on the "play" button on the web player.
* Playback doesn't start.