### PR TITLE
Bump javax' servlet version

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -298,6 +298,7 @@
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
             <scope>runtime</scope>
+            <version>1.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Apparently, there is an XXE in the version that we're using (1.1.2)
