### PR TITLE
Change avatar storage column to bytea for PostgreSQL

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -3,6 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <property name="binary_type" dbms="hsqldb" value="binary" />
+    <property name="binary_type" dbms="postgresql" value="bytea" />
     <property name="binary_type" value="blob" />
     <property name="curr_date_expr" value="current_timestamp" />
     <property name="varchar_type" dbms="mariadb,mysql" value="varchar(${mysqlVarcharLimit})" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema35.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema35.xml
@@ -59,6 +59,20 @@
             </delete>
         </rollback>
     </changeSet>
+    <changeSet id="schema35_005_fix_binary_type" author="fxthomas" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="system_avatar" />
+            <sqlCheck expectedResult="oid">
+                SELECT DATA_TYPE
+                FROM INFORMATION_SCHEMA.COLUMNS
+                WHERE TABLE_NAME = 'system_avatar'
+                AND COLUMN_NAME = 'data'
+            </sqlCheck>
+        </preConditions>
+        <!-- Kept for compatibility with people with an existing table using the workaround in #1213 -->
+        <sql>ALTER TABLE system_avatar ALTER COLUMN data TYPE bytea USING lo_get(data);</sql>
+        <rollback></rollback>
+    </changeSet>
     <changeSet id="schema35_005" author="muff1nman">
         <validCheckSum>8:d428266eb794ae2f1361a6eec0f67672</validCheckSum>
         <preConditions onFail="MARK_RAN">
@@ -90,6 +104,20 @@
         <rollback>
             <dropTable tableName="system_avatar" />
         </rollback>
+    </changeSet>
+    <changeSet id="schema35_006_fix_binary_type" author="fxthomas" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="custom_avatar" />
+            <sqlCheck expectedResult="oid">
+                SELECT DATA_TYPE
+                FROM INFORMATION_SCHEMA.COLUMNS
+                WHERE TABLE_NAME = 'custom_avatar'
+                AND COLUMN_NAME = 'data'
+            </sqlCheck>
+        </preConditions>
+        <!-- Kept for compatibility with people with an existing table using the workaround in #1213 -->
+        <sql>ALTER TABLE custom_avatar ALTER COLUMN data TYPE bytea USING lo_get(data);</sql>
+        <rollback></rollback>
     </changeSet>
     <changeSet id="schema35_006" author="muff1nman">
         <validCheckSum>8:60a4f99dea63d7813457a1b8f981f763</validCheckSum>


### PR DESCRIPTION
In PostgreSQL, Liquibase maps the `blob` type to an `oid` column by
default[1]. That column type is not supported[2] very well when using
the `valueBlobFile` attribute, which expects a `bytea` column instead.

This was confirmed on all PostgreSQL versions starting from 9.6 (Airsonic
fails to start in all cases).

The `validCheckSum` attribute does not need to be updated since it was
already for the previous (binary_type, varchar_type) combination in
an unrelated commit (78a99d58604169db4a0d2a1f5c9c490fa32dc49b).

Fixes #1213.

[1] https://liquibase.jira.com/browse/CORE-1863
[2] https://github.com/liquibase/liquibase/pull/605