### PR TITLE
Turn off Airsonic banner during tests

### DIFF
--- a/airsonic-main/src/test/resources/application.properties
+++ b/airsonic-main/src/test/resources/application.properties
@@ -1,3 +1,4 @@
+spring.main.banner-mode=off
 spring.mvc.view.prefix: /WEB-INF/jsp/
 spring.mvc.view.suffix: .jsp
 server.error.includeStacktrace: ALWAYS


### PR DESCRIPTION
The Airsonic ASCII art banner pollutes the output multiple times when running the unit/integration tests, how about removing it? Anybody against it?