### PR TITLE
Avoid exceptions if Lucene index is not ready on first startup

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
@@ -311,8 +311,10 @@ public class IndexManager {
                 } else {
                     LOG.warn("{} does not exist. Please run a scan.", indexDirectory.getAbsolutePath());
                 }
+            } catch (IndexNotFoundException e) {
+                LOG.debug("Index {} does not exist in {}, likely not yet created.", indexType.toString(), indexDirectory.getAbsolutePath());
             } catch (IOException e) {
-                LOG.error("Failed to initialize SearcherManager.", e);
+                LOG.warn("Failed to initialize SearcherManager.", e);
             }
         }
         try {


### PR DESCRIPTION
If the library is large enough, Airsonic finishes loading the
application before the first (automatic) scan is completed. The
exception is then shown on the home page until the scan completes.

Fixes #1402.