### PR TITLE
Make a couple of inner classes static

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
@@ -326,7 +326,7 @@ public class UserDao extends AbstractDao {
         }
     }
 
-    private class UserRowMapper implements RowMapper<User> {
+    private static class UserRowMapper implements RowMapper<User> {
         public User mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new User(rs.getString(1),
                     decrypt(rs.getString(2)),

--- a/airsonic-main/src/main/java/org/airsonic/player/service/InternetRadioService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/InternetRadioService.java
@@ -42,7 +42,7 @@ public class InternetRadioService {
     /**
      * Generic exception class for playlists.
      */
-    private class PlaylistException extends Exception {
+    private static class PlaylistException extends Exception {
         public PlaylistException(String message) {
             super(message);
         }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistServiceTestImport.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistServiceTestImport.java
@@ -182,7 +182,7 @@ public class PlaylistServiceTestImport {
         assertEquals(3, mediaFiles.size());
     }
 
-    private class PersistPlayList implements Answer {
+    private static class PersistPlayList implements Answer {
         private final int id;
         public PersistPlayList(int id) {
             this.id = id;
@@ -196,7 +196,7 @@ public class PlaylistServiceTestImport {
         }
     }
 
-    private class MediaFileHasEverything implements Answer {
+    private static class MediaFileHasEverything implements Answer {
 
         @Override
         public Object answer(InvocationOnMock invocationOnMock) {


### PR DESCRIPTION
This might marginally improve the memory consumption,
but the main goal here is to make the code separation
between inner and outer class explicit.
