### PR TITLE
Clean up a bit the jaudiotagger wrapper

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -624,11 +624,7 @@ public class MediaFileService {
         // Look for embedded images in audiofiles. (Only check first audio file encountered).
         for (File candidate : candidates) {
             if (parser.isApplicable(candidate)) {
-                if (parser.isImageAvailable(getMediaFile(candidate))) {
-                    return candidate;
-                } else {
-                    return null;
-                }
+                return JaudiotaggerParser.getArtwork(getMediaFile(candidate)) != null ? candidate : null;
             }
         }
         return null;


### PR DESCRIPTION
- ID3v24 are now fully supported by jaudiotagger,
  there is no need to have special code to handle
  them
- Inline a couple of one-line'n'useless methods
- Replace isImageAvailable with getArtwork
- Make some methods static
- Specialize some exceptions