### PR TITLE
Set limit in random track query itself instead of in connection

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AbstractDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AbstractDao.java
@@ -102,16 +102,6 @@ public class AbstractDao {
         return result;
     }
 
-    protected <T> List<T> namedQueryWithLimit(String sql, RowMapper<T> rowMapper, Map<String, Object> args, int limit) {
-        long t = System.nanoTime();
-        JdbcTemplate jdbcTemplate = new JdbcTemplate(daoHelper.getDataSource());
-        jdbcTemplate.setMaxRows(limit);
-        NamedParameterJdbcTemplate namedTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
-        List<T> result = namedTemplate.query(sql, args, rowMapper);
-        log(sql, t);
-        return result;
-    }
-
     protected List<String> queryForStrings(String sql, Object... args) {
         long t = System.nanoTime();
         List<String> result = getJdbcTemplate().queryForList(sql, args, String.class);

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
@@ -592,7 +592,9 @@ public class MediaFileDao extends AbstractDao {
 
         query += " order by rand()";
 
-        return namedQueryWithLimit(query, rowMapper, args, criteria.getCount());
+        query += " limit " + criteria.getCount();
+
+        return namedQuery(query, rowMapper, args);
     }
 
     public int getAlbumCount(final List<MusicFolder> musicFolders) {


### PR DESCRIPTION
This allows query plan optimization.

This is a direct backport of
https://github.com/airsonic-advanced/airsonic-advanced/commit/f84644ae3df80fe4918844b62035b6bffeeed824