### PR TITLE
WIP: Add option to disable "not very secure" t+s REST API auth

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -126,6 +126,7 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
             restAuthenticationFilter.setSecurityService(securityService);
             restAuthenticationFilter.setEventPublisher(eventPublisher);
             http = http.addFilterBefore(restAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+            http.httpBasic();
 
             // Try to load the 'remember me' key.
             //

--- a/airsonic-main/src/main/java/org/airsonic/player/security/RESTRequestParameterProcessingFilter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/RESTRequestParameterProcessingFilter.java
@@ -180,6 +180,7 @@ public class RESTRequestParameterProcessingFilter implements Filter {
                 "{}: Client tried to use deprecated token+salt authentication while loading {}",
                 httpRequest.getRemoteAddr(),
                 Util.getAnonymizedURLForRequest(httpRequest));
+            return null;
         }
 
         return SubsonicRESTController.ErrorCode.MISSING_PARAMETER;

--- a/airsonic-main/src/main/java/org/airsonic/player/security/RESTRequestParameterProcessingFilter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/RESTRequestParameterProcessingFilter.java
@@ -71,6 +71,8 @@ public class RESTRequestParameterProcessingFilter implements Filter {
 
     private static RequestMatcher requiresAuthenticationRequestMatcher = new RegexRequestMatcher("/rest/.+",null);
 
+    private static boolean hasTokenSaltWarningBeenSent = false;
+
     protected boolean requiresAuthentication(HttpServletRequest request,
                                              HttpServletResponse response) {
         return requiresAuthenticationRequestMatcher.matches(request);
@@ -176,10 +178,13 @@ public class RESTRequestParameterProcessingFilter implements Filter {
         }
 
         if (salt != null && token != null && !securityService.isTokenSaltAuthenticationAllowed()) {
-            LOG.warn(
-                "{}: Client tried to use deprecated token+salt authentication while loading {}",
-                httpRequest.getRemoteAddr(),
-                Util.getAnonymizedURLForRequest(httpRequest));
+            if (!hasTokenSaltWarningBeenSent) {
+                LOG.warn(
+                    "{}: Client tried to use deprecated token+salt authentication while loading {}",
+                    httpRequest.getRemoteAddr(),
+                    Util.getAnonymizedURLForRequest(httpRequest));
+                hasTokenSaltWarningBeenSent = true;
+            }
             return null;
         }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -347,4 +347,8 @@ public class SecurityService implements UserDetailsService {
     public void setUserCache(Ehcache userCache) {
         this.userCache = userCache;
     }
+
+    public boolean isTokenSaltAuthenticationAllowed() {
+        return settingsService.isTokenSaltAuthenticationAllowed();
+    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -133,6 +133,8 @@ public class SettingsService {
 
     private static final String KEY_UPNP_PORT = "UPNP_PORT";
 
+    private static final String KEY_TOKEN_SALT_AUTHENTICATION_ALLOWED = "TokenSaltAuthenticationAllowed";
+
     // Default values.
     private static final String DEFAULT_JWT_KEY = null;
     private static final String DEFAULT_INDEX_STRING = "A B C D E F G H I J K L M N O P Q R S T U V W X-Z(XYZ)";
@@ -213,6 +215,8 @@ public class SettingsService {
     private static final String DEFAULT_DATABASE_USERTABLE_QUOTE = null;
 
     private static final int DEFAULT_UPNP_PORT = 4041;
+
+    private static final boolean DEFAULT_TOKEN_SALT_AUTHENTICATION_ALLOWED = true;
 
     // Array of obsolete keys.  Used to clean property file.
     private static final List<String> OBSOLETE_KEYS = Arrays.asList("PortForwardingPublicPort", "PortForwardingLocalPort",
@@ -1369,6 +1373,14 @@ public class SettingsService {
 
     public void setDatabaseConfigEmbedUrl(String url) {
         setString(KEY_DATABASE_CONFIG_EMBED_URL, url);
+    }
+
+    public boolean isTokenSaltAuthenticationAllowed() {
+        return getBoolean(KEY_TOKEN_SALT_AUTHENTICATION_ALLOWED, DEFAULT_TOKEN_SALT_AUTHENTICATION_ALLOWED);
+    }
+
+    public void setTokenSaltAuthenticationAllowed(boolean value) {
+        setBoolean(KEY_TOKEN_SALT_AUTHENTICATION_ALLOWED, value);
     }
 
     public String getDatabaseConfigEmbedUsername() {


### PR DESCRIPTION
This is a very early attempt following discussion in #69, showing what I had in mind in https://github.com/airsonic/airsonic/issues/69#issuecomment-573786360.

Note that I had to explicitly enable HTTP Basic Auth so that DSub works for me (it transmits the `Authorization` header in addition to either `t+s` or `p` parameters but that wasn't taken into account by Airsonic), not sure if that's the right way or if I did something wrong in my configuration.

Also, in its current form this spams the logs with warnings about the auth method if used with an app that tries to supply `t+s` (as DSub does).

At least the branch is here so that folks can test it.

