### PR TITLE
Allow configuring JVM Heap when run within a docker container.

### DIFF
--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.9
 LABEL description="Airsonic is a free, web-based media streamer, providing ubiquitious access to your music." \
       url="https://github.com/airsonic/airsonic"
 
-ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/airsonic CONTEXT_PATH=/ UPNP_PORT=4041
+ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/airsonic CONTEXT_PATH=/ UPNP_PORT=4041 JVM_HEAP=256m
 
 WORKDIR $AIRSONIC_DIR
 

--- a/install/docker/run.sh
+++ b/install/docker/run.sh
@@ -12,7 +12,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
     while IFS= read -r -d '' item; do
         java_opts_array+=( "$item" )
     done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
-    exec java -Xmx256m \
+    exec java -Xmx${JVM_HEAP} \
      -Dserver.host=0.0.0.0 \
      -Dserver.port=$AIRSONIC_PORT \
      -Dserver.contextPath=$CONTEXT_PATH \


### PR DESCRIPTION
JVM Heap in the docker container can now be configured by the JVM_HEAP env var, example:

```
docker run -e JVM_HEAP=512m airsonic/airsonic
```

Signed-off-by: Paul Rogalinski-Pinter <paul@paul.vc>