### PR TITLE
Update mysql-connector-java to 8.0.19

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -554,7 +554,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.43</version>
+            <version>8.0.19</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Airsonic does not work with MySQL 8, which I discovered recently lately during testing and development. I did not see any issue with upgrading to the latest version of the JDBC driver.

Tested with Docker:
```
docker run --name mysql -e MYSQL_DATABASE=airsonic -e MYSQL_ROOT_PASSWORD=123456 -p 3306:3306 -d mysql:8.0 --character-set-server=utf8 --collation-server=utf8_general_ci
```