### PR TITLE
Update index version following Lucene upgrade to 8.4.1

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
@@ -74,7 +74,7 @@ public class IndexManager {
      *    DocumentFactory or the class that they use.
      *
      */
-    private static final int INDEX_VERSION = 17;
+    private static final int INDEX_VERSION = 18;
 
     /**
      * Literal name of index top directory.


### PR DESCRIPTION
After #1488, when upgrading from a previously existing index built with Lucene 8.2.0, Airsonic
fails to start with the following error:

    java.lang.IllegalArgumentException: Could not load codec 'Lucene80'.  Did you forget to add lucene-backward-codecs.jar?
      at org.apache.lucene.index.SegmentInfos.readCodec(SegmentInfos.java:420) ~[lucene-core-8.4.1.jar!/:8.4.1 832bf13dd9187095831caf69783179d41059d013 - ishan - 2020-01-10 13:35:00]
      ...
      at org.apache.lucene.search.SearcherManager.<init>(SearcherManager.java:125) ~[lucene-core-8.4.1.jar!/:8.4.1 832bf13dd9187095831caf69783179d41059d013 - ishan - 2020-01-10 13:35:00]
      at org.airsonic.player.service.search.IndexManager.getSearcher(IndexManager.java:309) ~[classes!/:10.6.0-SNAPSHOT]
      at org.airsonic.player.service.search.IndexManager.getStatistics(IndexManager.java:269) ~[classes!/:10.6.0-SNAPSHOT]
      at org.airsonic.player.service.MediaScannerService.neverScanned(MediaScannerService.java:121) ~[classes!/:10.6.0-SNAPSHOT]
      at org.airsonic.player.service.MediaScannerService.schedule(MediaScannerService.java:114) ~[classes!/:10.6.0-SNAPSHOT]
      at org.airsonic.player.service.MediaScannerService.init(MediaScannerService.java:77) ~[classes!/:10.6.0-SNAPSHOT]