### PR TITLE
Added support for (multistage) docker based builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+target/
+.idea
+Dockerfile
+docker-compose.yaml

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+################################################################################################################ builder
+
+FROM maven:3-jdk-8 as builder
+WORKDIR /build
+
+# this block will make docker cache the dependencies for subsequent builds of the same image.
+COPY pom.xml .
+COPY subsonic-rest-api/pom.xml ./subsonic-rest-api/pom.xml
+COPY integration-test/pom.xml ./integration-test/pom.xml
+COPY airsonic-sonos-api/pom.xml ./airsonic-sonos-api/pom.xml
+COPY airsonic-main/pom.xml ./airsonic-main/pom.xml
+RUN mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+
+COPY . .
+RUN mvn package
+
+################################################################################################################ runtime
+
+FROM alpine:3.9 as runtime
+LABEL description="Airsonic is a free, web-based media streamer, providing ubiquitious access to your music." \
+      url="https://github.com/airsonic/airsonic"
+ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/airsonic CONTEXT_PATH=/ UPNP_PORT=4041 JVM_HEAP=256m
+
+WORKDIR $AIRSONIC_DIR
+RUN apk --no-cache add \
+    ffmpeg \
+    lame \
+    bash \
+    libressl \
+    fontconfig \
+    ttf-dejavu \
+    ca-certificates \
+    tini \
+    curl \
+    openjdk8-jre
+COPY install/docker/run.sh /usr/local/bin/run.sh
+RUN chmod +x /usr/local/bin/run.sh
+COPY --from=builder  /build/airsonic-main/target/airsonic.war airsonic.war
+EXPOSE $AIRSONIC_PORT
+EXPOSE $UPNP_PORT
+EXPOSE 1900/udp
+VOLUME $AIRSONIC_DIR/data $AIRSONIC_DIR/music $AIRSONIC_DIR/playlists $AIRSONIC_DIR/podcasts
+HEALTHCHECK --interval=15s --timeout=3s CMD wget -q http://localhost:"$AIRSONIC_PORT""$CONTEXT_PATH"rest/ping -O /dev/null || exit 1
+ENTRYPOINT ["tini", "--", "run.sh"]


### PR DESCRIPTION
This PR allows for automated Docker Hub image builds and local builds which require just a docker dependency instead of JDK+Maven. 

# Usage

## Previous approach to build a docker image

```
mvn -P docker package
````

## Recommended approach after this PR

```
docker build -t airsonic .
````

### Automated image builds by Docker Hub

For integration with Docker Hub set up Automated Builds linked to the official Airsonic Github Repository and configure *one* build rule matching the release tags to mimic the current release/tagging vs image tagging scheme:

```
Source Type: Tag
Source: /^v([0-9.]+)$/
Docker-Tag: {\1}-RELEASE,latest
```

![Docker Hub Configuration](https://user-images.githubusercontent.com/1245126/74605992-16d81880-50cd-11ea-8658-da3c0ded1286.png)

# Open for discussion:

Should the `dockerfile-maven-plugin` / `docker` maven module be removed in favor of this approach in a subsequent PR? The plugin`s README.md states:  "At this point, we're not developing or accepting new features or even fixing non-critical bugs."

Signed-off-by: Paul Rogalinski-Pinter <paul@paul.vc>