### PR TITLE
Add separate password for Subsonic API

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/PersonalSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/PersonalSettingsController.java
@@ -120,11 +120,22 @@ public class PersonalSettingsController {
     }
 
     @PostMapping
-    protected String doSubmitAction(@ModelAttribute("command") PersonalSettingsCommand command, @RequestParam(value = "regenerateRestToken", required = false) String regenerateRestToken, RedirectAttributes redirectAttributes) {
+    protected String doSubmitAction(
+            @ModelAttribute("command") PersonalSettingsCommand command,
+            @RequestParam(value = "regenerateRestToken", required = false) String regenerateRestToken,
+            @RequestParam(value = "clearRestToken", required = false) String clearRestToken,
+            RedirectAttributes redirectAttributes) {
 
         if (regenerateRestToken != null) {
             User user = command.getUser();
             userDao.updateRestTokenForUser(user);
+            return "redirect:personalSettings.view";
+        }
+
+        if (clearRestToken != null) {
+            User user = command.getUser();
+            user.setRestToken(null);
+            userDao.updateUser(user);
             return "redirect:personalSettings.view";
         }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/PersonalSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/PersonalSettingsController.java
@@ -20,6 +20,7 @@
 package org.airsonic.player.controller;
 
 import org.airsonic.player.command.PersonalSettingsCommand;
+import org.airsonic.player.dao.UserDao;
 import org.airsonic.player.domain.*;
 import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.SettingsService;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.servlet.http.HttpServletRequest;
@@ -51,6 +53,8 @@ public class PersonalSettingsController {
     private SettingsService settingsService;
     @Autowired
     private SecurityService securityService;
+    @Autowired
+    private UserDao userDao;
 
     @ModelAttribute
     protected void formBackingObject(HttpServletRequest request,Model model) {
@@ -116,7 +120,13 @@ public class PersonalSettingsController {
     }
 
     @PostMapping
-    protected String doSubmitAction(@ModelAttribute("command") PersonalSettingsCommand command, RedirectAttributes redirectAttributes) {
+    protected String doSubmitAction(@ModelAttribute("command") PersonalSettingsCommand command, @RequestParam(value = "regenerateRestToken", required = false) String regenerateRestToken, RedirectAttributes redirectAttributes) {
+
+        if (regenerateRestToken != null) {
+            User user = command.getUser();
+            userDao.updateRestTokenForUser(user);
+            return "redirect:personalSettings.view";
+        }
 
         int localeIndex = Integer.parseInt(command.getLocaleIndex());
         Locale locale = null;

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
@@ -42,7 +42,7 @@ import java.util.List;
 public class UserDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(UserDao.class);
-    private static final String USER_COLUMNS = "username, password, email, ldap_authenticated, bytes_streamed, bytes_downloaded, bytes_uploaded";
+    private static final String USER_COLUMNS = "username, password, rest_token, email, ldap_authenticated, bytes_streamed, bytes_downloaded, bytes_uploaded";
     private static final String USER_SETTINGS_COLUMNS = "username, locale, theme_id, final_version_notification, beta_version_notification, " +
             "song_notification, main_track_number, main_artist, main_album, main_genre, " +
             "main_year, main_bit_rate, main_duration, main_format, main_file_size, " +
@@ -137,7 +137,7 @@ public class UserDao extends AbstractDao {
      */
     public void createUser(User user) {
         String sql = "insert into " + getUserTable() + " (" + USER_COLUMNS + ") values (" + questionMarks(USER_COLUMNS) + ')';
-        update(sql, user.getUsername(), encrypt(user.getPassword()), user.getEmail(), user.isLdapAuthenticated(),
+        update(sql, user.getUsername(), encrypt(user.getPassword()), user.getRestToken(), user.getEmail(), user.isLdapAuthenticated(),
                 user.getBytesStreamed(), user.getBytesDownloaded(), user.getBytesUploaded());
         writeRoles(user);
     }
@@ -163,9 +163,9 @@ public class UserDao extends AbstractDao {
      * @param user The user to update.
      */
     public void updateUser(User user) {
-        String sql = "update " + getUserTable() + " set password=?, email=?, ldap_authenticated=?, bytes_streamed=?, bytes_downloaded=?, bytes_uploaded=? " +
+        String sql = "update " + getUserTable() + " set password=?, rest_token=?, email=?, ldap_authenticated=?, bytes_streamed=?, bytes_downloaded=?, bytes_uploaded=? " +
                 "where username=?";
-        getJdbcTemplate().update(sql, encrypt(user.getPassword()), user.getEmail(), user.isLdapAuthenticated(),
+        getJdbcTemplate().update(sql, encrypt(user.getPassword()), user.getRestToken(), user.getEmail(), user.isLdapAuthenticated(),
                 user.getBytesStreamed(), user.getBytesDownloaded(), user.getBytesUploaded(),
                 user.getUsername());
         writeRoles(user);
@@ -331,10 +331,11 @@ public class UserDao extends AbstractDao {
             return new User(rs.getString(1),
                     decrypt(rs.getString(2)),
                     rs.getString(3),
-                    rs.getBoolean(4),
-                    rs.getLong(5),
+                    rs.getString(4),
+                    rs.getBoolean(5),
                     rs.getLong(6),
-                    rs.getLong(7));
+                    rs.getLong(7),
+                    rs.getLong(8));
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
@@ -21,6 +21,7 @@ package org.airsonic.player.dao;
 
 import org.airsonic.player.domain.*;
 import org.airsonic.player.util.StringUtil;
+import org.apache.commons.lang.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -169,6 +170,16 @@ public class UserDao extends AbstractDao {
                 user.getBytesStreamed(), user.getBytesDownloaded(), user.getBytesUploaded(),
                 user.getUsername());
         writeRoles(user);
+    }
+
+
+    /**
+     * Updates the given user with a new REST token.
+     * @param user
+     */
+    public void updateRestTokenForUser(User user) {
+        user.setRestToken(RandomStringUtils.randomAlphanumeric(20));
+        this.updateUser(user);
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/User.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/User.java
@@ -49,7 +49,9 @@ public class User {
     private boolean isJukeboxRole;
     private boolean isShareRole;
 
-    public User(String username, String password, String email, boolean ldapAuthenticated,
+    private String restToken;
+
+    public User(String username, String password, String restToken, String email, boolean ldapAuthenticated,
                 long bytesStreamed, long bytesDownloaded, long bytesUploaded) {
         this.username = username;
         this.password = password;
@@ -58,10 +60,11 @@ public class User {
         this.bytesStreamed = bytesStreamed;
         this.bytesDownloaded = bytesDownloaded;
         this.bytesUploaded = bytesUploaded;
+        this.restToken = restToken;
     }
 
     public User(String username, String password, String email) {
-        this(username, password, email, false, 0, 0, 0);
+        this(username, password, null, email, false, 0, 0, 0);
     }
 
     public String getUsername() {
@@ -202,6 +205,14 @@ public class User {
 
     public void setShareRole(boolean shareRole) {
         isShareRole = shareRole;
+    }
+
+    public String getRestToken() {
+        return restToken;
+    }
+
+    public void setRestToken(String restToken) {
+        this.restToken = restToken;
     }
 
     @Override

--- a/airsonic-main/src/main/java/org/airsonic/player/security/CustomUserDetailsContextMapper.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/CustomUserDetailsContextMapper.java
@@ -65,7 +65,7 @@ public class CustomUserDetailsContextMapper implements UserDetailsContextMapper 
         }
 
         if (user == null) {
-            User newUser = new User(username, "", null, true, 0L, 0L, 0L);
+            User newUser = new User(username, "", null, null, true, 0L, 0L, 0L);
             newUser.setStreamRole(true);
             newUser.setSettingsRole(true);
             securityService.createUser(newUser);

--- a/airsonic-main/src/main/java/org/airsonic/player/security/RESTAuthenticationProvider.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/RESTAuthenticationProvider.java
@@ -1,0 +1,45 @@
+package org.airsonic.player.security;
+
+import org.airsonic.player.service.SecurityService;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+
+public class RESTAuthenticationProvider extends DaoAuthenticationProvider {
+
+    public RESTAuthenticationProvider() {
+        super();
+        setPasswordEncoder(NoOpPasswordEncoder.getInstance());
+    }
+
+    @Override
+    protected void additionalAuthenticationChecks(UserDetails userDetails,
+                                                  UsernamePasswordAuthenticationToken authentication) throws AuthenticationException {
+        if (!SecurityService.UserDetail.class.isAssignableFrom(userDetails.getClass())) {
+            throw new InternalAuthenticationServiceException("Invalid user details class");
+        }
+        String restToken = ((SecurityService.UserDetail)userDetails).getRestToken();
+        if (restToken == null) {
+            throw new BadCredentialsException("Empty REST token");
+        }
+        User restUser = new org.springframework.security.core.userdetails.User(
+                userDetails.getUsername(),
+                restToken,
+                userDetails.isEnabled(),
+                userDetails.isAccountNonExpired(),
+                userDetails.isCredentialsNonExpired(),
+                userDetails.isAccountNonLocked(),
+                userDetails.getAuthorities());
+        super.additionalAuthenticationChecks(restUser, authentication);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return RESTAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/security/RESTAuthenticationToken.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/RESTAuthenticationToken.java
@@ -1,0 +1,16 @@
+package org.airsonic.player.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class RESTAuthenticationToken extends UsernamePasswordAuthenticationToken {
+    public RESTAuthenticationToken(Object principal, Object credentials) {
+        super(principal, credentials);
+    }
+
+    public RESTAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -41,6 +41,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -59,6 +60,39 @@ public class SecurityService implements UserDetailsService {
     private SettingsService settingsService;
     @Autowired
     private Ehcache userCache;
+
+    public static class UserDetail extends org.springframework.security.core.userdetails.User {
+        private String restToken;
+
+        public UserDetail(
+                String username,
+                String password,
+                Collection<? extends GrantedAuthority> authorities) {
+            super(username, password, authorities);
+            this.restToken = restToken;
+        }
+
+        public UserDetail(
+                String username,
+                String password,
+                String restToken,
+                boolean enabled,
+                boolean accountNonExpired,
+                boolean credentialsNonExpired,
+                boolean accountNonLocked,
+                Collection<? extends GrantedAuthority> authorities) {
+            super(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
+            this.restToken = restToken;
+        }
+
+        public String getRestToken() {
+            return restToken;
+        }
+
+        public void setRestToken(String restToken) {
+            this.restToken = restToken;
+        }
+    }
 
     /**
      * Locates the user based on the username.
@@ -81,9 +115,10 @@ public class SecurityService implements UserDetailsService {
 
         List<GrantedAuthority> authorities = getGrantedAuthorities(username);
 
-        return new org.springframework.security.core.userdetails.User(
+        return new UserDetail(
                 username,
                 user.getPassword(),
+                user.getRestToken(),
                 !user.isLdapAuthenticated(),
                 true,
                 true,

--- a/airsonic-main/src/main/resources/liquibase/10.6/add-rest-token-to-user.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.6/add-rest-token-to-user.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-rest-token-to-user" author="fxthomas">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="user" columnName="rest_token" />
+            </not>
+        </preConditions>
+        <addColumn tableName="user">
+            <column name="rest_token" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/10.6/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.6/changelog.xml
@@ -4,4 +4,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <include file="add-media-file-mb-recording-id.xml" relativeToChangelogFile="true"/>
     <include file="support-listenbrainz.xml" relativeToChangelogFile="true"/>
+    <include file="add-rest-token-to-user.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -448,6 +448,11 @@ personalsettings.avatar.custom=Custom image
 personalsettings.avatar.changecustom=Change custom image
 personalsettings.avatar.upload=Upload
 personalsettings.avatar.courtesy=Icons courtesy of <a href="http://www.afterglow.ie/" target="_blank">Afterglow</a>, <a href="http://www.aha-soft.com/" target="_blank">Aha-Soft</a>, <a href="http://www.icons-land.com/" target="_blank">Icons-Land</a>, and <a href="http://www.iconshock.com/" target="_blank">Iconshock</a>
+personalsettings.api.title=Subsonic API
+personalsettings.api.password=API Password
+personalsettings.api.regenerate=Regenerate
+personalsettings.api.none=none
+personalsettings.api.passwordhelp=Use this password for accessing your Airsonic library in compatible apps.
 
 avataruploadresult.title=Change personal image
 avataruploadresult.success=Personal image "{0}" uploaded.

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -451,6 +451,7 @@ personalsettings.avatar.courtesy=Icons courtesy of <a href="http://www.afterglow
 personalsettings.api.title=Subsonic API
 personalsettings.api.password=API Password
 personalsettings.api.regenerate=Regenerate
+personalsettings.api.clear=Clear
 personalsettings.api.none=none
 personalsettings.api.passwordhelp=Use this password for accessing your Airsonic library in compatible apps.
 

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
@@ -37,6 +37,7 @@
                     </c:otherwise>
                 </c:choose>
             </td>
+            <td><input type="submit" value="<fmt:message key='personalsettings.api.regenerate'/>" name="regenerateRestToken"/></td>
         </tr>
     </table>
 </form:form>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
@@ -38,6 +38,7 @@
                 </c:choose>
             </td>
             <td><input type="submit" value="<fmt:message key='personalsettings.api.regenerate'/>" name="regenerateRestToken"/></td>
+            <td><input type="submit" value="<fmt:message key='personalsettings.api.clear'/>" name="clearRestToken"/></td>
         </tr>
     </table>
 </form:form>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
@@ -22,6 +22,26 @@
     <c:param name="toast" value="${settings_toast}"/>
 </c:import>
 
+<h2><fmt:message key="personalsettings.api.title"/></h2>
+<form:form method="post" action="personalSettings.view">
+    <table class="indent">
+        <tr>
+            <td><fmt:message key="personalsettings.api.password"/></td>
+            <td class="restToken">
+                <c:choose>
+                    <c:when test="${empty command.user.restToken}">
+                        (<fmt:message key="personalsettings.api.none"/>)
+                    </c:when>
+                    <c:otherwise>
+                        ${command.user.restToken}
+                    </c:otherwise>
+                </c:choose>
+            </td>
+        </tr>
+    </table>
+</form:form>
+<p><fmt:message key="personalsettings.api.passwordhelp"/></p>
+
 <fmt:message key="personalsettings.title" var="title"><fmt:param>${command.user.username}</fmt:param></fmt:message>
 <h2>${fn:escapeXml(title)}</h2>
 

--- a/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
+++ b/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
@@ -443,6 +443,14 @@ img {
     color: black;
 }
 
+.restToken {
+    font-family: monospace;
+    padding: 5px;
+    border-width: 1px;
+    border-color: black;
+    border-style: solid;
+}
+
 /*
  * Styles related to java jukebox controls
  */

--- a/airsonic-main/src/main/webapp/style/groove.css
+++ b/airsonic-main/src/main/webapp/style/groove.css
@@ -108,3 +108,7 @@ html {
 label, p {
 	color: #CCC;
 }
+
+.restToken {
+    border-color: white;
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/api/AirsonicRestApiIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/AirsonicRestApiIntTest.java
@@ -1,7 +1,10 @@
 package org.airsonic.player.api;
 
 import org.airsonic.player.TestCaseUtils;
+import org.airsonic.player.dao.UserDao;
+import org.airsonic.player.domain.User;
 import org.airsonic.player.util.HomeRule;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -28,11 +31,14 @@ public class AirsonicRestApiIntTest {
     private static final String AIRSONIC_USER = "admin";
     private static final String AIRSONIC_PASSWORD = "admin";
     private static final String EXPECTED_FORMAT = "json";
+    private static final String CLIENT_SALT = "testsalt";
 
     private static String AIRSONIC_API_VERSION;
 
     @Autowired
     private MockMvc mvc;
+    @Autowired
+    private UserDao userDao;
 
     @ClassRule
     public static final HomeRule classRule = new HomeRule(); // sets airsonic.home to a temporary dir
@@ -54,6 +60,70 @@ public class AirsonicRestApiIntTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
                 .andExpect(jsonPath("$.subsonic-response.version").value(AIRSONIC_API_VERSION))
+                .andDo(print());
+    }
+
+    @Test
+    public void pingTestWithRestToken() throws Exception {
+
+        User user = userDao.getUserByName(AIRSONIC_USER, true);
+        userDao.updateRestTokenForUser(user);
+
+        mvc.perform(get("/rest/ping")
+                .param("v", AIRSONIC_API_VERSION)
+                .param("c", CLIENT_NAME)
+                .param("u", AIRSONIC_USER)
+                .param("p", user.getRestToken())
+                .param("f", EXPECTED_FORMAT)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+                .andExpect(jsonPath("$.subsonic-response.version").value(AIRSONIC_API_VERSION))
+                .andDo(print());
+    }
+
+    @Test
+    public void pingTestWithRestTokenSalt() throws Exception {
+
+        User user = userDao.getUserByName(AIRSONIC_USER, true);
+        userDao.updateRestTokenForUser(user);
+
+        String expectedToken = DigestUtils.md5Hex(user.getRestToken() + CLIENT_SALT);
+
+        mvc.perform(get("/rest/ping")
+                .param("v", AIRSONIC_API_VERSION)
+                .param("c", CLIENT_NAME)
+                .param("u", AIRSONIC_USER)
+                .param("t", expectedToken)
+                .param("s", CLIENT_SALT)
+                .param("f", EXPECTED_FORMAT)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+                .andExpect(jsonPath("$.subsonic-response.version").value(AIRSONIC_API_VERSION))
+                .andDo(print());
+    }
+
+    @Test
+    public void pingTestWithSalt() throws Exception {
+
+        String expectedToken = DigestUtils.md5Hex(AIRSONIC_PASSWORD + CLIENT_SALT);
+
+        mvc.perform(get("/rest/ping")
+                .param("v", AIRSONIC_API_VERSION)
+                .param("c", CLIENT_NAME)
+                .param("u", AIRSONIC_USER)
+                .param("t", expectedToken)
+                .param("s", CLIENT_SALT)
+                .param("f", EXPECTED_FORMAT)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+                .andExpect(jsonPath("$.subsonic-response.version").value(AIRSONIC_API_VERSION))
+                // FIXME: Uncomment this (and remove the "ok" lines above) when the t+s auth method is removed
+                //.andExpect(jsonPath("$.subsonic-response.status").value("failed"))
+                //.andExpect(jsonPath("$.subsonic-response.version").value(AIRSONIC_API_VERSION))
+                //.andExpect(jsonPath("$.subsonic-response.error.code").value(40))
                 .andDo(print());
     }
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/LoginControllerIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/LoginControllerIntTest.java
@@ -1,0 +1,54 @@
+package org.airsonic.player.controller;
+
+import junit.framework.TestCase;
+import org.airsonic.player.dao.UserDao;
+import org.airsonic.player.domain.User;
+import org.airsonic.player.util.HomeRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class LoginControllerIntTest extends TestCase {
+
+    private static final String AIRSONIC_USER = "admin";
+    private static final String AIRSONIC_PASSWORD = "admin";
+
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private UserDao userDao;
+
+    @ClassRule
+    public static final HomeRule classRule = new HomeRule(); // sets airsonic.home to a temporary dir
+
+    @Test
+    public void testPasswordLogin() throws Exception {
+        mvc.perform(formLogin("/login")
+                .user("j_username", AIRSONIC_USER)
+                .password("j_password", AIRSONIC_PASSWORD))
+                .andExpect(authenticated());
+    }
+
+    @Test
+    public void testRestTokenLogin() throws Exception {
+        User user = userDao.getUserByName(AIRSONIC_USER, true);
+        userDao.updateRestTokenForUser(user);
+
+        mvc.perform(formLogin("/login")
+                .user("j_username", AIRSONIC_USER)
+                .password("j_password", user.getRestToken()))
+                .andExpect(unauthenticated());
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/PersonalSettingsControllerIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/PersonalSettingsControllerIntTest.java
@@ -1,0 +1,84 @@
+package org.airsonic.player.controller;
+
+import junit.framework.TestCase;
+import org.airsonic.player.dao.UserDao;
+import org.airsonic.player.domain.User;
+import org.airsonic.player.util.HomeRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PersonalSettingsControllerIntTest extends TestCase {
+
+    private static final String AIRSONIC_USER = "user";
+    private static final String AIRSONIC_PASSWORD = "password";
+
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private UserDao userDao;
+
+    @ClassRule
+    public static final HomeRule classRule = new HomeRule(); // sets airsonic.home to a temporary dir
+
+    @Before
+    public void setup() throws Exception {
+        userDao.createUser(new User(AIRSONIC_USER, AIRSONIC_PASSWORD, "user@example.com"));
+    }
+
+    @After
+    public void destroy() throws Exception {
+        userDao.deleteUser(AIRSONIC_USER);
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"USER", "SETTINGS"})
+    public void testRegenerateRestToken() throws Exception {
+        User user = userDao.getUserByName(AIRSONIC_USER, true);
+        user.setRestToken(null);
+        userDao.updateUser(user);
+
+        mvc.perform(post("/personalSettings.view")
+                .with(csrf())
+                .param("regenerateRestToken", "true")
+                .contentType(MediaType.TEXT_HTML))
+                .andExpect(status().is3xxRedirection());
+
+        user = userDao.getUserByName(AIRSONIC_USER, true);
+        assertNotNull(user.getRestToken());
+        assertTrue(user.getRestToken().length() == 20);
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = {"USER", "SETTINGS"})
+    public void testClearRestToken() throws Exception {
+        User user = userDao.getUserByName(AIRSONIC_USER, true);
+        userDao.updateRestTokenForUser(user);
+        assertNotNull(user.getRestToken());
+
+        mvc.perform(post("/personalSettings.view")
+                .with(csrf())
+                .param("clearRestToken", "true")
+                .contentType(MediaType.TEXT_HTML))
+                .andExpect(status().is3xxRedirection());
+
+        user = userDao.getUserByName(AIRSONIC_USER, true);
+        assertNull(user.getRestToken());
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
@@ -32,7 +32,7 @@ public class UserDaoTestCase extends DaoTestCaseBean2 {
 
     @Test
     public void testCreateUser() {
-        User user = new User("sindre", "secret", "sindre@activeobjects.no", false, 1000L, 2000L, 3000L);
+        User user = new User("sindre", "secret", null, "sindre@activeobjects.no", false, 1000L, 2000L, 3000L);
         user.setAdminRole(true);
         user.setCommentRole(true);
         user.setCoverArtRole(true);


### PR DESCRIPTION
This series of commits adds a single separate password for the Subsonic API:

![Screenshot from 2020-02-18 23-26-06](https://user-images.githubusercontent.com/613594/74783478-15ae1380-52a6-11ea-863a-dea9df8bf048.png)

This password ("REST token" in the code for now, should we use "Subsonic API password" instead?) is empty by default, but can be regenerated or cleared in the "Personal Settings" page.

By default, existing users will see no changes:
* Either the regular user password or this token (if not empty) can authenticate requests to the Subsonic API.
* Other requests (web UI) cannot use this token and must continue to use the user password as before.

Following #69, the t+s login using the user password can then be removed as a breaking change in 11.0 alongside the introduction of hashed user passwords. After this point, users with apps using the t+s login will need to change their password to use the REST token.

Note that another, more complex proposal was discussed in #69 and implemented in another PR in another fork. I think the issues pointed to by #69 need at least a minimal solution in place for 10.6 before we start breaking things in 11.0, hence this PR.