### PR TITLE
Fix not to perform clean up during scan

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
@@ -313,8 +313,10 @@ public class IndexManager {
                 }
             } catch (IndexNotFoundException e) {
                 LOG.debug("Index {} does not exist in {}, likely not yet created.", indexType.toString(), indexDirectory.getAbsolutePath());
+                return null;
             } catch (IOException e) {
                 LOG.warn("Failed to initialize SearcherManager.", e);
+                return null;
             }
         }
         try {


### PR DESCRIPTION
It is follow-up of #1459.

After 015c7c5 apply, performing a cleanup during scan will cause the following error on all subsequent file scans:


```
java.lang.NullPointerException: null
        at org.airsonic.player.service.search.IndexManager.index(IndexManager.java:145) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.service.MediaScannerService.scanFile(MediaScannerService.java:237) [classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.service.MediaScannerService.scanFile(MediaScannerService.java:244) [classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.service.MediaScannerService.scanFile(MediaScannerService.java:244) [classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.service.MediaScannerService.doScanLibrary(MediaScannerService.java:183) [classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.service.MediaScannerService.access$000(MediaScannerService.java:50) [classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.service.MediaScannerService$1.run(MediaScannerService.java:151) [classes!/:10.6.0-SNAPSHOT]
```

