### PR TITLE
Update commons-configuration2 2.6 -> 2.7 (fixes CVE)

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -412,7 +412,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
Fixes the current CVE error on master.