### PR TITLE
Fix 'add playlist to queue' buttons on the UI

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -384,8 +384,8 @@
     function onAddNext(id) {
         playQueueService.addAt(id, getCurrentSongIndex() + 1, playQueueCallback);
     }
-    function onAddPlaylist(id, index) {
-        playQueueService.addPlaylist(id, index, playQueueCallback);
+    function onAddPlaylist(id) {
+        playQueueService.addPlaylist(id, playQueueCallback);
     }
     function onShuffle() {
         playQueueService.shuffle(playQueueCallback);


### PR DESCRIPTION
The addPlaylist method was modified in 90e63817 to remove the unused (and actually broken) 'index' parameter, but this change was not done properly on the JS side.