### PR TITLE
Fix #1585

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceUtilities.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceUtilities.java
@@ -102,6 +102,7 @@ public class SearchServiceUtilities {
         for (String algorithmName : new String[]{"NativePRNG", "SHA1PRNG"}) {
             if (algorithms.contains(algorithmName)) {
                 random = createSecureRandom(algorithmName);
+                break;
             }
         }
 


### PR DESCRIPTION
When both NativePRNG and SHA1PRNG exist, NativePRNG has priority.