### PR TITLE
Revert escription of a exception in JaudiotaggerParser 

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -27,7 +27,6 @@ import org.jaudiotagger.audio.AudioFile;
 import org.jaudiotagger.audio.AudioFileIO;
 import org.jaudiotagger.audio.AudioHeader;
 import org.jaudiotagger.tag.FieldKey;
-import org.jaudiotagger.tag.KeyNotFoundException;
 import org.jaudiotagger.tag.Tag;
 import org.jaudiotagger.tag.images.Artwork;
 import org.jaudiotagger.tag.reference.GenreTypes;
@@ -68,7 +67,7 @@ public class JaudiotaggerParser extends MetaDataParser {
     static {
         try {
             LogManager.getLogManager().reset();
-        } catch (SecurityException x) {
+        } catch (Throwable x) {
             LOG.warn("Failed to turn off logging from Jaudiotagger.", x);
         }
     }
@@ -83,41 +82,41 @@ public class JaudiotaggerParser extends MetaDataParser {
     public MetaData getRawMetaData(File file) {
 
         MetaData metaData = new MetaData();
-        AudioFile audioFile;
+
         try {
-            audioFile = AudioFileIO.read(file);
-        } catch (Exception x) {
+            AudioFile audioFile = AudioFileIO.read(file);
+            Tag tag = audioFile.getTag();
+            if (tag != null) {
+                metaData.setAlbumArtist(getTagField(tag, FieldKey.ALBUM_ARTIST));
+                metaData.setAlbumName(getTagField(tag, FieldKey.ALBUM));
+                metaData.setArtist(getTagField(tag, FieldKey.ARTIST));
+                metaData.setDiscNumber(parseInteger(getTagField(tag, FieldKey.DISC_NO)));
+                metaData.setGenre(mapGenre(getTagField(tag, FieldKey.GENRE)));
+                metaData.setMusicBrainzRecordingId(getTagField(tag, FieldKey.MUSICBRAINZ_TRACK_ID));
+                metaData.setMusicBrainzReleaseId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEID));
+                metaData.setTitle(getTagField(tag, FieldKey.TITLE));
+                metaData.setTrackNumber(parseIntegerPattern(getTagField(tag, FieldKey.TRACK), TRACK_NUMBER_PATTERN));
+                metaData.setYear(parseIntegerPattern(getTagField(tag, FieldKey.YEAR), YEAR_NUMBER_PATTERN));
+
+                if (StringUtils.isBlank(metaData.getArtist())) {
+                    metaData.setArtist(metaData.getAlbumArtist());
+                }
+                if (StringUtils.isBlank(metaData.getAlbumArtist())) {
+                    metaData.setAlbumArtist(metaData.getArtist());
+                }
+
+            }
+
+            AudioHeader audioHeader = audioFile.getAudioHeader();
+            if (audioHeader != null) {
+                metaData.setVariableBitRate(audioHeader.isVariableBitRate());
+                metaData.setBitRate((int) audioHeader.getBitRateAsNumber());
+                metaData.setDurationSeconds(audioHeader.getTrackLength());
+            }
+
+
+        } catch (Throwable x) {
             LOG.warn("Error when parsing tags in " + file, x);
-            return metaData;
-        }
-
-        Tag tag = audioFile.getTag();
-        if (tag != null) {
-            metaData.setAlbumArtist(getTagField(tag, FieldKey.ALBUM_ARTIST));
-            metaData.setAlbumName(getTagField(tag, FieldKey.ALBUM));
-            metaData.setArtist(getTagField(tag, FieldKey.ARTIST));
-            metaData.setDiscNumber(parseInteger(getTagField(tag, FieldKey.DISC_NO)));
-            metaData.setGenre(mapGenre(getTagField(tag, FieldKey.GENRE)));
-            metaData.setMusicBrainzRecordingId(getTagField(tag, FieldKey.MUSICBRAINZ_TRACK_ID));
-            metaData.setMusicBrainzReleaseId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEID));
-            metaData.setTitle(getTagField(tag, FieldKey.TITLE));
-            metaData.setTrackNumber(parseIntegerPattern(getTagField(tag, FieldKey.TRACK), TRACK_NUMBER_PATTERN));
-            metaData.setYear(parseIntegerPattern(getTagField(tag, FieldKey.YEAR), YEAR_NUMBER_PATTERN));
-
-            if (StringUtils.isBlank(metaData.getArtist())) {
-                metaData.setArtist(metaData.getAlbumArtist());
-            }
-            if (StringUtils.isBlank(metaData.getAlbumArtist())) {
-                metaData.setAlbumArtist(metaData.getArtist());
-            }
-
-        }
-
-        AudioHeader audioHeader = audioFile.getAudioHeader();
-        if (audioHeader != null) {
-            metaData.setVariableBitRate(audioHeader.isVariableBitRate());
-            metaData.setBitRate((int) audioHeader.getBitRateAsNumber());
-            metaData.setDurationSeconds(audioHeader.getTrackLength());
         }
 
         return metaData;
@@ -126,7 +125,7 @@ public class JaudiotaggerParser extends MetaDataParser {
     private static String getTagField(Tag tag, FieldKey fieldKey) {
         try {
             return StringUtils.trimToNull(tag.getFirst(fieldKey));
-        } catch (KeyNotFoundException x) {
+        } catch (Exception x) {
             // Ignored.
             return null;
         }
@@ -229,7 +228,7 @@ public class JaudiotaggerParser extends MetaDataParser {
 
             audioFile.commit();
 
-        } catch (Exception x) {
+        } catch (Throwable x) {
             LOG.warn("Failed to update tags for file " + file, x);
             throw new RuntimeException("Failed to update tags for file " + file + ". " + x.getMessage(), x);
         }
@@ -281,8 +280,8 @@ public class JaudiotaggerParser extends MetaDataParser {
         AudioFile audioFile;
         try {
             audioFile = AudioFileIO.read(file.getFile());
-        } catch (Exception e) {
-            LOG.info("Failed to find cover art tag in " + file, e);
+        } catch (Throwable e) {
+            LOG.warn("Failed to find cover art tag in " + file, e);
             return null;
         }
         Tag tag = audioFile.getTag();


### PR DESCRIPTION
This is a revert for the #1625.
Due to lack of verification, we will also revert exception descriptions other than those reported.

It is a revert (patch) to instant recover the deterioration that cannot be untraceable by the user.
Another new exception description, logging and test addition (refactoring) should be done in another PR.

Note : CHANGELOG.md