### PR TITLE
Fix UTF-8 detection on some systems using non-standard locales

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/InternalHelpController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/InternalHelpController.java
@@ -284,6 +284,22 @@ public class InternalHelpController {
         }
     }
 
+    /**
+     * Returns true if a locale string (e.g. en_US.UTF-8) appears to support UTF-8 correctly.
+     *
+     * Some systems use non-standard locales (e.g. en_US.utf8 instead of en_US.UTF-8)
+     * to specify Unicode support, which are usually supported by the Glibc.
+     *
+     * See: https://superuser.com/questions/999133/differences-between-en-us-utf8-and-en-us-utf-8
+     */
+    private boolean doesLocaleSupportUtf8(String locale) {
+        if (locale == null) {
+            return false;
+        } else {
+            return locale.toLowerCase().replaceAll("\\W", "").contains("utf8");
+        }
+    }
+
     private void gatherLocaleInfo(Map<String, Object> map) {
         map.put("localeDefault", Locale.getDefault());
         map.put("localeUserLanguage", System.getProperty("user.language"));
@@ -293,7 +309,12 @@ public class InternalHelpController {
         map.put("localeSunIoUnicodeEncoding", System.getProperty("sun.io.unicode.encoding"));
         map.put("localeLang", System.getenv("LANG"));
         map.put("localeLcAll", System.getenv("LC_ALL"));
-        map.put("localeDefaultCharset", Charset.defaultCharset());
+        map.put("localeDefaultCharset", Charset.defaultCharset().toString());
+
+        map.put("localeFileEncodingSupportsUtf8", doesLocaleSupportUtf8(System.getProperty("file.encoding")));
+        map.put("localeLangSupportsUtf8", doesLocaleSupportUtf8(System.getenv("LANG")));
+        map.put("localeLcAllSupportsUtf8", doesLocaleSupportUtf8(System.getenv("LC_ALL")));
+        map.put("localeDefaultCharsetSupportsUtf8", doesLocaleSupportUtf8(Charset.defaultCharset().toString()));
     }
 
     private void gatherDatabaseInfo(Map<String, Object> map) {

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/internalhelp.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/internalhelp.jsp
@@ -287,7 +287,7 @@
     <tr>
         <td colspan="2" class="ruleTableCell">
             <c:choose>
-                <c:when test="${fn:contains(model.localeDefaultCharset, 'UTF-8')}">
+                <c:when test="${model.localeDefaultCharsetSupportsUtf8}">
                     <img src="<spring:theme code='checkImage'/>" alt="OK">
                     <fmt:message key="internalhelp.defaultcharset.ok"/>
                 </c:when>
@@ -305,7 +305,7 @@
     <tr>
         <td colspan="2" class="ruleTableCell">
             <c:choose>
-                <c:when test="${fn:contains(model.localeFileEncoding, 'UTF-8')}">
+                <c:when test="${model.localeFileEncodingSupportsUtf8}">
                     <img src="<spring:theme code='checkImage'/>" alt="OK">
                     <fmt:message key="internalhelp.file.encoding.ok"/>
                 </c:when>
@@ -320,7 +320,7 @@
     <tr><td class="ruleTableHeader"><fmt:message key="internalhelp.sun.jnu.encoding"/></td><td class="ruleTableCell">${model.localeSunJnuEncoding}</td></tr>
     <tr><td class="ruleTableHeader"><fmt:message key="internalhelp.sun.io.unicode.encoding"/></td><td class="ruleTableCell">${model.localeSunIoUnicodeEncoding}</td></tr>
 
-    <c:if test="${not empty model.localeLang and not fn:contains(model.localeLang, 'UTF-8')}">
+    <c:if test="${not empty model.localeLang and not model.localeLangSupportsUtf8}">
         <tr>
             <td colspan="2" class="ruleTableCell">
                 <img src="<spring:theme code='alertImage'/>" alt="Warning">
@@ -330,7 +330,7 @@
     </c:if>
     <tr><td class="ruleTableHeader"><fmt:message key="internalhelp.langvar"/></td><td class="ruleTableCell">${model.localeLang}</td></tr>
 
-    <c:if test="${not empty model.localeLcAll and not fn:contains(model.localeLcAll, 'UTF-8')}">
+    <c:if test="${not empty model.localeLcAll and not model.localeLcAllSupportsUtf8}">
         <tr>
             <td colspan="2" class="ruleTableCell">
                 <img src="<spring:theme code='alertImage'/>" alt="Warning">


### PR DESCRIPTION
Some systems use non-standard locales (e.g. `en_US.utf8` instead of `en_US.UTF-8`) to specify Unicode support. These locales are supported by Glibc but were not handled properly by the Airsonic diagnostics page.

From [Reddit comment](https://www.reddit.com/r/airsonic/comments/g46qm2/airsonic_1061_released/fo39yyd):

> My "About Airsonic Internals" says, "The LANG environment variable is defined but appears to disable UTF-8 support. International characters may be partially supported."
>
> LANG environment variable           en_US.utf8
>
> is this an issue?