### PR TITLE
Fix date format used in podcast filename generation

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -657,7 +657,8 @@ public class PodcastService {
 
         File channelDir = getChannelDirectory(channel);
 
-        String episodeDate = String.format("%tY-%tm-%td", episode.getPublishDate());
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        String episodeDate = simpleDateFormat.format(episode.getPublishDate());
         String filename = channel.getTitle() + " - " + episodeDate + " - " + episode.getId() + " - " + episode.getTitle();
         filename = filename.substring(0, Math.min(filename.length(), 146));
 


### PR DESCRIPTION
This fixes a crash when downloading podcasts introduced by c65fa1671.