### PR TITLE
Add some null-checks on calls to mediaFileService.getMediaFile()

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -1716,6 +1716,10 @@ public class SubsonicRESTController {
 
         Bookmarks result = new Bookmarks();
         for (Bookmark bookmark : bookmarkService.getBookmarks(username)) {
+            MediaFile mediaFile = mediaFileService.getMediaFile(bookmark.getMediaFileId());
+            if (mediaFile == null) {
+                continue;
+            } 
             org.subsonic.restapi.Bookmark b = new org.subsonic.restapi.Bookmark();
             result.getBookmark().add(b);
             b.setPosition(bookmark.getPositionMillis());
@@ -1723,11 +1727,7 @@ public class SubsonicRESTController {
             b.setComment(bookmark.getComment());
             b.setCreated(jaxbWriter.convertDate(bookmark.getCreated()));
             b.setChanged(jaxbWriter.convertDate(bookmark.getChanged()));
-
-            MediaFile mediaFile = mediaFileService.getMediaFile(bookmark.getMediaFileId());
-            if (mediaFile != null) {
-                b.setEntry(createJaxbChild(player, mediaFile, username));
-            }
+            b.setEntry(createJaxbChild(player, mediaFile, username));
         }
 
         Response res = createResponse();

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -1210,7 +1210,7 @@ public class SubsonicRESTController {
             Player player = status.getPlayer();
             MediaFile mediaFile = status.getMediaFile();
             String username = player.getUsername();
-            if (username == null) {
+            if (player == null || mediaFile == null || username == null) {
                 continue;
             }
 
@@ -1601,8 +1601,10 @@ public class SubsonicRESTController {
         String path = episode.getPath();
         if (path != null) {
             MediaFile mediaFile = mediaFileService.getMediaFile(path);
-            e = createJaxbChild(new org.subsonic.restapi.PodcastEpisode(), player, mediaFile, username);
-            e.setStreamId(String.valueOf(mediaFile.getId()));
+            if (mediaFile != null) {
+                e = createJaxbChild(new org.subsonic.restapi.PodcastEpisode(), player, mediaFile, username);
+                e.setStreamId(String.valueOf(mediaFile.getId()));
+            }
         }
 
         e.setId(String.valueOf(episode.getId()));  // Overwrites the previous "id" attribute.
@@ -1723,7 +1725,9 @@ public class SubsonicRESTController {
             b.setChanged(jaxbWriter.convertDate(bookmark.getChanged()));
 
             MediaFile mediaFile = mediaFileService.getMediaFile(bookmark.getMediaFileId());
-            b.setEntry(createJaxbChild(player, mediaFile, username));
+            if (mediaFile != null) {
+                b.setEntry(createJaxbChild(player, mediaFile, username));
+            }
         }
 
         Response res = createResponse();
@@ -1843,7 +1847,10 @@ public class SubsonicRESTController {
 
         List<MediaFile> files = new ArrayList<MediaFile>();
         for (int id : getRequiredIntParameters(request, "id")) {
-            files.add(mediaFileService.getMediaFile(id));
+            MediaFile mediaFile = mediaFileService.getMediaFile(id);
+            if (mediaFile != null) {
+                files.add(mediaFile);
+            }
         }
 
         org.airsonic.player.domain.Share share = shareService.createShare(request, files);

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -1719,7 +1719,7 @@ public class SubsonicRESTController {
             MediaFile mediaFile = mediaFileService.getMediaFile(bookmark.getMediaFileId());
             if (mediaFile == null) {
                 continue;
-            } 
+            }
             org.subsonic.restapi.Bookmark b = new org.subsonic.restapi.Bookmark();
             result.getBookmark().add(b);
             b.setPosition(bookmark.getPositionMillis());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/RatingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/RatingService.java
@@ -59,7 +59,10 @@ public class RatingService {
         for (String path : highestRated) {
             File file = new File(path);
             if (FileUtil.exists(file) && securityService.isReadAllowed(file)) {
-                result.add(mediaFileService.getMediaFile(path));
+                MediaFile mediaFile = mediaFileService.getMediaFile(path);
+                if (mediaFile != null) {
+                    result.add(mediaFile);
+                }
             }
         }
         return result;


### PR DESCRIPTION
Missing null-checks on mediaFileService.getMediaFile() cause NPEs in the Subsonic API and elsewhere, add some checks to avoid these.

Especially the NPE in the Subsonic API is annoying since it leads to a loss of functionality, e.g. empty podcast listings in DSub etc.

```
ERROR --- o.a.p.s.LoggingExceptionResolver: 192.168.1.136:
An exception occurred while loading https://music.example.org/rest/getPodcasts.view?v=1.2.0&c=DSub&id=11&t=<hidden>&s=<hidden>&u=<hidden>
java.lang.NullPointerException: null
#011at org.airsonic.player.service.MediaFileService.getParentOf(MediaFileService.java:156) ~[classes!/:11.0.0-SNAPSHOT]
#011at org.airsonic.player.controller.SubsonicRESTController.createJaxbChild(SubsonicRESTController.java:1243) ~[classes!/:11.0.0-SNAPSHOT]
#011at org.airsonic.player.controller.SubsonicRESTController.createJaxbPodcastEpisode(SubsonicRESTController.java:1606) ~[classes!/:11.0.0-SNAPSHOT]
#011at org.airsonic.player.controller.SubsonicRESTController.getPodcasts(SubsonicRESTController.java:1572) ~[classes!/:11.0.0-SNAPSHOT]
...
```
