### PR TITLE
use String.format("%tF") instead of "%tY-%tm-%td" 

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -657,7 +657,7 @@ public class PodcastService {
 
         File channelDir = getChannelDirectory(channel);
 
-        String episodeDate = String.format("%tY-%tm-%td", episode.getPublishDate());
+        String episodeDate = String.format("%tF", episode.getPublishDate());
         String filename = channel.getTitle() + " - " + episodeDate + " - " + episode.getId() + " - " + episode.getTitle();
         filename = filename.substring(0, Math.min(filename.length(), 146));
 


### PR DESCRIPTION
As to why java suddenly started complaining about `java.util.MissingFormatArgumentException: Format specifier '%tm'` errors I have no idea but the fact is that it did as of the 1st of may 2020:
```
Failed to download Podcast from https://example.com/1.mp3
java.util.MissingFormatArgumentException: Format specifier '%tm'
```

Given that the intention of this format string is to produce an ISO date (_YYYY-MM-DD_) and given that `String.format` has a special formatter for this which does _not_ produce this error it seems logical to use it.
