### PR TITLE
Save "add to playlist"-dialog size

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
@@ -27,12 +27,15 @@
             minBorder: 30
         });
 
-        $("#dialog-select-playlist").dialog({resizable: true, height: 350, autoOpen: false,
+        var dialogSize = getJQueryUiDialogPlaylistSize("albumMain");
+        $("#dialog-select-playlist").dialog({resizable: true, height: dialogSize.height, width: dialogSize.width, autoOpen: false,
             buttons: {
                 "<fmt:message key="common.cancel"/>": function() {
                     $(this).dialog("close");
                 }
-            }});
+            },
+            resizeStop: function (event, ui) { setJQueryUiDialogPlaylistSize("albumMain", ui.size) }
+        });
 
         <c:if test="${model.showArtistInfo}">
         loadArtistInfo();

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -65,12 +65,15 @@
         dwr.engine.setErrorHandler(null);
         startTimer();
 
-        $("#dialog-select-playlist").dialog({resizable: true, height: 220, autoOpen: false,
+        var dialogSize = getJQueryUiDialogPlaylistSize("playQueue");
+        $("#dialog-select-playlist").dialog({resizable: true, height: dialogSize.height, width: dialogSize.width, autoOpen: false,
             buttons: {
-                "<fmt:message key="common.cancel"/>": function() {
+                "<fmt:message key="common.cancel"/>": function () {
                     $(this).dialog("close");
                 }
-            }});
+            },
+            resizeStop: function (event, ui) { setJQueryUiDialogPlaylistSize("playQueue", ui.size) }
+        });
 
         <c:if test="${model.player.web}">createMediaElementPlayer();</c:if>
 

--- a/airsonic-main/src/main/webapp/script/utils.js
+++ b/airsonic-main/src/main/webapp/script/utils.js
@@ -40,3 +40,41 @@ function updateQueryStringParameter(uri, key, value) {
         return uri + separator + key + "=" + value;
     }
 }
+
+function setCookie(name, value, days) {
+    var expires = "";
+    if (days) {
+        var date = new Date();
+        date.setTime(date.getTime() + (days*24*60*60*1000));
+        expires = "; expires=" + date.toUTCString();
+    }
+    document.cookie = name + "=" + (value || "")  + expires + "; path=/";
+}
+
+function getCookie(name) {
+    var nameEQ = name + "=";
+    var ca = document.cookie.split(';');
+    for(var i=0;i < ca.length;i++) {
+        var c = ca[i];
+        while (c.charAt(0)==' ') c = c.substring(1,c.length);
+        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+    }
+    return null;
+}
+
+function getJQueryUiDialogPlaylistSize(origin) {
+    var width = getCookie("dialog-select-playlist-" + origin + "-width");
+    var height = getCookie("dialog-select-playlist-" + origin + "-height");
+    if (!width) {
+        width = 300;
+    }
+    if (!height) {
+        height = 250;
+    }
+    return {width: width, height: height};
+}
+
+function setJQueryUiDialogPlaylistSize(origin, size) {
+    setCookie("dialog-select-playlist-" + origin + "-width", parseInt(size.width), 365);
+    setCookie("dialog-select-playlist-" + origin + "-height", parseInt(size.height), 365);
+}


### PR DESCRIPTION
This pull request is a copy of https://github.com/airsonic-advanced/airsonic-advanced/pull/303

This pull request adds the ability to save the size of the dialog, showing when adding tracks to a playlist. I found it very annoying to change the size of this dialog every time.

The size is saved in cookies. This makes it very lightweight and also adds the possibility to have different sizes on different computers/browsers for the same user/player.

The size of the dialog, shown when adding from the album view, is stored in a different cookie then the dialog shown, when adding from the player queue. Even though the initial size is 300 width and 250 height for both (height was 350 for mediaMain and 220 for playQueue).