### PR TITLE
Issue #1685

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -295,7 +295,11 @@ public class CoverArtController implements LastModified {
             try {
                 LOG.trace("Reading artwork from file {}", mediaFile);
                 artwork = jaudiotaggerParser.getArtwork(mediaFile);
-                is = new ByteArrayInputStream(artwork.getBinaryData());
+                byte[] binaryData = artwork.getBinaryData();
+                if( binaryData != null )                
+                	is = new ByteArrayInputStream(binaryData);
+                else
+                	is = new FileInputStream(file);
                 mimeType = artwork.getMimeType();
             } catch (Exception e) {
                 LOG.debug("Could not read artwork from file {}", mediaFile);


### PR DESCRIPTION
PR: Fixes Issue #1685 

NPE of issuze occurs, if artwork binary data has a size of 0. 

Introduced null-check in `CoverArtController` will return a default `InputStream` in that case. The log message now is ` WARN --- o.a.p.c.CoverArtController               : Failed to process cover art /tmp/file.mp3: ImageIO.read failed`, instead of a NullPointerException stack trace.

Signed-off-by: wolkenschieber <wolkenschieber@users.noreply.github.com>