### PR TITLE
Redirect from main to podcastChannel view

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/MainController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/MainController.java
@@ -56,12 +56,20 @@ public class MainController {
     private RatingService ratingService;
     @Autowired
     private MediaFileService mediaFileService;
+    @Autowired
+    private PodcastService podcastService;
 
     @GetMapping
     protected ModelAndView handleRequestInternal(@RequestParam(name = "showAll", required = false) Boolean showAll,
                                                  HttpServletRequest request,
                                                  HttpServletResponse response) throws Exception {
         Map<String, Object> map = new HashMap<>();
+
+        //redirect if podcast channel
+        int[] requestParameterIds = ServletRequestUtils.getIntParameters(request, "id");
+        if (requestParameterIds.length == 1 && isPodcast(requestParameterIds[0])) {
+            return new ModelAndView(new RedirectView("/podcastChannel.view?id=" + getPodcastChannelId(requestParameterIds[0])));
+        }
 
         Player player = playerService.getPlayer(request, response);
         List<MediaFile> mediaFiles = getMediaFiles(request);
@@ -285,6 +293,16 @@ public class MainController {
             result.addAll(siblings.stream().filter(sibling -> sibling.isAlbum() && !sibling.equals(dir)).collect(Collectors.toList()));
         }
         return result;
+    }
+
+    private boolean isPodcast(int id) {
+        MediaFile mediaFile = mediaFileService.getMediaFile(id);
+        return mediaFile.isPodcast();
+    }
+
+    private int getPodcastChannelId(int id) {
+        MediaFile mediaFile = mediaFileService.getMediaFile(id);
+        return podcastService.getChannelIdByMediaFile(mediaFile);
     }
 
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
@@ -157,6 +157,11 @@ public class PodcastDao extends AbstractDao {
         return queryOne(sql, episodeRowMapper, url);
     }
 
+    public PodcastEpisode getEpisodeByPath(String path) {
+        String sql = "select " + EPISODE_QUERY_COLUMNS + " from podcast_episode where path=?";
+        return queryOne(sql, episodeRowMapper, path);
+    }
+
     /**
      * Updates the given Podcast episode.
      *

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -182,6 +182,10 @@ public class MediaFile {
         return mediaType == MediaType.ALBUM;
     }
 
+    public boolean isPodcast() {
+        return mediaType == MediaType.PODCAST;
+    }
+
     public String getTitle() {
         return title;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -177,6 +177,15 @@ public class PodcastService {
     }
 
     /**
+     * Returns a single Podcast channel id by media file.
+     */
+    public int getChannelIdByMediaFile(MediaFile mediaFile) {
+        return podcastDao.getEpisodeByPath(mediaFile.getPath()).getChannelId();
+    }
+
+
+
+    /**
      * Returns all Podcast channels.
      *
      * @return Possibly empty list of all Podcast channels.


### PR DESCRIPTION
This pull request is fixing this issue: https://github.com/airsonic/airsonic/issues/1554
It's a ported version of this: https://github.com/airsonic-advanced/airsonic-advanced/pull/307

_When clicking on several links of podcasts, you're getting to the album view of podcast, which actually shouldn't exist. You should get the podcast channel view.
This pull requests fixes all these links by forwarding from main.view to the corresponding podcastChannel.view. I found this approach way easier then changing all the links around in Airsonic (now playing/recently played, playlist and player)._