### PR TITLE
Fix podcast duration displayed in podcast channel

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -488,11 +488,8 @@ public class PodcastService {
     private String formatDuration(String duration) {
         if (duration == null) return null;
         if (duration.matches("^\\d+$")) {
-            long seconds = Long.valueOf(duration);
-            if (seconds >= 3600)
-                return String.format("%02d:%02d:%02d", seconds / 3600, seconds / 60, seconds % 60);
-            else
-                return String.format("%02d:%02d", seconds / 60, seconds % 60);
+            int seconds = Integer.valueOf(duration);
+            return StringUtil.formatDuration(seconds);
         } else {
             return duration;
         }


### PR DESCRIPTION
This pull request is fixing this issue: #1673
It was firstly reported in Airsonic-Advanced (https://github.com/airsonic-advanced/airsonic-advanced/issues/249) and fixed in Airsonic-Advanced (https://github.com/airsonic-advanced/airsonic-advanced/pull/252) by @randomnicode. So this is a backporting of the existing solution in Airsonic-Advanced.

For that pull request had to change the duration variable (seconds) from long to integer. But this shouldn't be an issue, as I don't expect to have podcasts with a duration of more then 68 year (2,147,483,647 / 60 / 60 / 24 / 365).

