### PR TITLE
Remove hidden clickable area around user icon in top

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
@@ -132,7 +132,7 @@
         </td>
 
         <td style="padding-left:15pt;padding-right:5pt;vertical-align: middle;width: 100%;text-align: center">
-            <c:if test="${model.user.settingsRole}"><a href="personalSettings.view" target="main"></c:if>
+            <c:if test="${model.user.settingsRole}"><a href="personalSettings.view" target="main" style="display: table; margin: auto;"></c:if>
             <c:choose>
                 <c:when test="${model.showAvatar}">
                     <sub:url value="avatar.view" var="avatarUrl">

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
@@ -132,7 +132,7 @@
         </td>
 
         <td style="padding-left:15pt;padding-right:5pt;vertical-align: middle;width: 100%;text-align: center">
-            <c:if test="${model.user.settingsRole}"><a href="personalSettings.view" target="main" style="display: table; margin: auto;"></c:if>
+            <c:if test="${model.user.settingsRole}"><a href="personalSettings.view" target="main" style="display: inline-block;"></c:if>
             <c:choose>
                 <c:when test="${model.showAvatar}">
                     <sub:url value="avatar.view" var="avatarUrl">


### PR DESCRIPTION
Around the username and the icon in the top frame is an area with a link where shouldn be a link:
![grafik](https://user-images.githubusercontent.com/9485516/84364778-d1d27780-abd0-11ea-9e76-0d2eb3427e17.png)

Firstly discovered here https://github.com/airsonic-advanced/airsonic-advanced/issues/222
It also got fixed in Airsonic-Advanced, but with a different approach https://github.com/airsonic-advanced/airsonic-advanced/pull/239