### PR TITLE
Prevent scrolling to top in playQueue and albumMain

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
@@ -136,7 +136,7 @@
         $("#dialog-select-playlist-list").empty();
         for (var i = 0; i < playlists.length; i++) {
             var playlist = playlists[i];
-            $("<p class='dense'><b><a href='#' onclick='appendPlaylist(" + playlist.id + ")'>" + escapeHtml(playlist.name)
+            $("<p class='dense'><b><a style='cursor: pointer' onclick='appendPlaylist(" + playlist.id + ")'>" + escapeHtml(playlist.name)
                     + "</a></b></p>").appendTo("#dialog-select-playlist-list");
         }
         $("#dialog-select-playlist").dialog("open");

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -479,7 +479,7 @@
         $("#dialog-select-playlist-list").empty();
         for (var i = 0; i < playlists.length; i++) {
             var playlist = playlists[i];
-            $("<p class='dense'><b><a href='#' onclick='appendPlaylist(" + playlist.id + ")'>" + escapeHtml(playlist.name)
+            $("<p class='dense'><b><a style='cursor: pointer' onclick='appendPlaylist(" + playlist.id + ")'>" + escapeHtml(playlist.name)
                     + "</a></b></p>").appendTo("#dialog-select-playlist-list");
         }
         $("#dialog-select-playlist").dialog("open");


### PR DESCRIPTION
This update prevents from scrolling to top after adding a track to a playlist in playQueue and albumMain.
Discovered while testing for #1751