### PR TITLE
Add fish shell CLI wrapper

### DIFF
--- a/contrib/airsonic.fish
+++ b/contrib/airsonic.fish
@@ -1,0 +1,59 @@
+#!/usr/bin/env fish
+
+# Put this in your .config/fish/functions folder and you'll get an `airsonic`
+# command that you can use to interact with the rest api. If you just want to
+# play around with it, use `source airsonic.fish` which provides you the same
+# command in your current session.
+
+function _airsonic_usage
+  echo 'Usage: airsonic [-h|--help] -u $user -p $pass [$url] $endpoint [...$params]'
+  echo
+  echo 'Interact with an airsonic server via REST. See http://www.subsonic.org/pages/api.jsp for additional documentation.'
+  echo
+  echo 'If you do not provide a $url, it is assumed the url can be found in $AIRSONIC_URL.'
+  echo 'Anything you pass in as $params will be directly passed on to httpie (see https://httpie.org/doc#querystring-parameters).'
+  echo
+  echo 'Parameters:'
+  echo
+  echo '  -h, --help	Prints this message'
+  echo '  -u, --user	Airsonic user'
+  echo '  -p, --pass	The user\'s password'
+end
+
+function airsonic -d "Convenience helper for interacting with an airsonic / subsonic server"
+  argparse "h/help" "u/user=" "p/pass=" -- $argv
+
+  if test (count $argv) -eq 0 -o (count $_flag_help) -eq 1
+    # print short usage description
+    _airsonic_usage
+    return 0
+  end
+
+  if not command -qs http
+    # check for dependencies
+    echo 'Aborting: Please install httpie. See https://httpie.org/ for instructions.'
+    return 1
+  end
+
+  if begin test -n "$AIRSONIC_URL"; and not string match -qr '^http' $argv[1]; end
+    # if we have an $AIRSONIC_URL and don't pass in a URL explicitly, use that
+    set url $AIRSONIC_URL
+  else
+    # otherwise use the first argument
+    set url $argv[1]
+    set argv $argv[2..(count $argv)]
+  end
+
+  if not string match -qr '^http' $url
+    # basic sanity checking
+    echo 'Please provide the URL of your airsonic instance as the first argument or set it as $AIRSONIC_URL'
+    return 1
+  end
+
+  set endpoint $argv[1]
+  if test (count $argv) -gt 1
+    set params $argv[2..(count $argv)]
+  end
+
+  http --follow -b $url/rest/$endpoint v==1.15.0 f==json u==$_flag_user  p==$_flag_pass c==airsonic-httpie $params
+end


### PR DESCRIPTION
I have written a simple command line wrapper in fish that I've been using happily for the past couple of months. It depends on [httpie](https://httpie.org/doc) and checks for the presence of that command when executed. It reduces dupliction immensely when intercting with the REST API.

[Here's an example](https://www.reddit.com/r/airsonic/comments/h9ly04/api_for_playing_a_random_podcast_episode/) of how it's used:

> 
> Getting a list of all podcasts:
> ```
> airsonic -u $user -p $pass getPodcasts includeEpisodes==1
> ```
> 
> Filtering for downloaded (and therefore streamable episodes):
> ```
> airsonic -u $user -p $pass getPodcasts includeEpisodes==1 | jq '.["subsonic-response"].podcasts.channel[].episode[] | select(.status == "completed")'
> ```
> 
> Initiating an episode download works like this:
> ```
> airsonic -u $user -p $pass downloadPodcastEpisode id==$id
> ```
> 
> You can get the correct `id` parameter from the `getPodcasts` response above.
> 
> Each episode has a property `streamId`, which you can use to stream it:
> ```
> airsonic -u $user -p $pass stream id==$streamId
> ```
> 
> So putting it togehter:
> 
> ```
> # select random podcast episode
> episode=$(airsonic -u $user -p $pass getPodcasts includeEpisodes==1 | jq -c '.["subsonic-response"].podcasts.channel[].episode[] | select(.status == "completed")' | shuf -n 1)
> # play episode
> airsonic -u $user -p $pass stream $(echo $episode | jq '.streamId') | play
> ```
