### PR TITLE
Update jaudiotagger source

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -253,7 +253,7 @@
         </dependency>
 
         <dependency>
-            <groupId>net.jthink</groupId>
+            <groupId>org.bitbucket.ijabz</groupId>
             <artifactId>jaudiotagger</artifactId>
             <version>2.2.5</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
             <url>file://${project.basedir}/../repo</url>
         </repository>
         <repository>
-            <id>jaudiotagger-repository</id>
-            <url>https://dl.bintray.com/ijabz/maven</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
         <repository>
           <id>4thline-repo</id>


### PR DESCRIPTION
Bintray [has been sunsetted](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). This was causing errors in the Maven Unit Tests:

```
[ERROR] Failed to execute goal on project airsonic-main: Could not resolve dependencies for project

org.airsonic.player:airsonic-main:war:10.6.2-RELEASE: Failed to collect dependencies at

net.jthink:jaudiotagger:jar:2.2.5: Failed to read artifact descriptor for net.jthink:jaudiotagger:jar:2.2.5: Could not

transfer artifact net.jthink:jaudiotagger:pom:2.2.5 from/to jaudiotagger-repository (https://dl.bintray.com/ijabz/maven):

Authorization failed for https://dl.bintray.com/ijabz/maven/net/jthink/jaudiotagger/2.2.5/jaudiotagger-2.2.5.pom 403 Forbidden -> [Help 1]
```

We can switch the source to [JitPack](https://jitpack.io/#org.bitbucket.ijabz/jaudiotagger) if we want to. This fixes the error for me. But if there is a better way to source this I am all ears.